### PR TITLE
Also generate json schema using the JSON name as the primary name

### DIFF
--- a/internal/testdata/jsonschema/buf.protoschema.test.v1.CustomOptions.jsonschema.json
+++ b/internal/testdata/jsonschema/buf.protoschema.test.v1.CustomOptions.jsonschema.json
@@ -1,0 +1,33 @@
+{
+  "$id": "buf.protoschema.test.v1.CustomOptions.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(int32_field)$": {
+      "items": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "^(string_field)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "int32Field": {
+      "items": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "stringField": {
+      "type": "string"
+    }
+  },
+  "title": "Custom Options",
+  "type": "object"
+}

--- a/internal/testdata/jsonschema/buf.protoschema.test.v1.IgnoreField.jsonschema.json
+++ b/internal/testdata/jsonschema/buf.protoschema.test.v1.IgnoreField.jsonschema.json
@@ -1,0 +1,25 @@
+{
+  "$id": "buf.protoschema.test.v1.IgnoreField.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(bool_field)$": {
+      "type": "boolean"
+    },
+    "^(bytes_field|bytesField)$": {
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "^(nested_reference|nestedReference)$": {
+      "$ref": "buf.protoschema.test.v1.NestedReference.jsonschema.json",
+      "description": "jsonschema:hide"
+    }
+  },
+  "properties": {
+    "boolField": {
+      "type": "boolean"
+    }
+  },
+  "title": "Ignore Field",
+  "type": "object"
+}

--- a/internal/testdata/jsonschema/buf.protoschema.test.v1.NestedReference.jsonschema.json
+++ b/internal/testdata/jsonschema/buf.protoschema.test.v1.NestedReference.jsonschema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "buf.protoschema.test.v1.NestedReference.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(nested_message)$": {
+      "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+    }
+  },
+  "properties": {
+    "nestedMessage": {
+      "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+    }
+  },
+  "title": "Nested Reference",
+  "type": "object"
+}

--- a/internal/testdata/jsonschema/bufext.cel.expr.conformance.proto3.NestedTestAllTypes.jsonschema.json
+++ b/internal/testdata/jsonschema/bufext.cel.expr.conformance.proto3.NestedTestAllTypes.jsonschema.json
@@ -1,0 +1,16 @@
+{
+  "$id": "bufext.cel.expr.conformance.proto3.NestedTestAllTypes.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "This proto includes a recursively nested message.",
+  "properties": {
+    "child": {
+      "$ref": "bufext.cel.expr.conformance.proto3.NestedTestAllTypes.jsonschema.json"
+    },
+    "payload": {
+      "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.jsonschema.json"
+    }
+  },
+  "title": "Nested Test All Types",
+  "type": "object"
+}

--- a/internal/testdata/jsonschema/bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json
+++ b/internal/testdata/jsonschema/bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "bb": {
+      "description": "The field name \"b\" fails to compile in proto1 because it conflicts with\n a local variable named \"b\" in one of the generated methods.\n This file needs to compile in proto1 to test backwards-compatibility.",
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    }
+  },
+  "title": "Nested Message",
+  "type": "object"
+}

--- a/internal/testdata/jsonschema/bufext.cel.expr.conformance.proto3.TestAllTypes.jsonschema.json
+++ b/internal/testdata/jsonschema/bufext.cel.expr.conformance.proto3.TestAllTypes.jsonschema.json
@@ -1,0 +1,5858 @@
+{
+  "$id": "bufext.cel.expr.conformance.proto3.TestAllTypes.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "This proto includes every type of field in both singular and repeated\n forms.",
+  "patternProperties": {
+    "^(list_value)$": {
+      "$ref": "google.protobuf.ListValue.jsonschema.json"
+    },
+    "^(map_bool_any)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Any.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_bool)$": {
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_bool_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BoolValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_bytes)$": {
+      "additionalProperties": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_bytes_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BytesValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_double)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "enum": [
+              "NaN",
+              "Infinity",
+              "-Infinity"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_double_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.DoubleValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_duration)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Duration.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_enum)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_float)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "enum": [
+              "NaN",
+              "Infinity",
+              "-Infinity"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_float_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.FloatValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_int32)$": {
+      "additionalProperties": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_int32_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_int64)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_int64_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_list_value)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.ListValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_message)$": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_null_value)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_string)$": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_string_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.StringValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_struct)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Struct.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_timestamp)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Timestamp.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_uint32)$": {
+      "additionalProperties": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_uint32_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_uint64)$": {
+      "additionalProperties": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_uint64_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_value)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_int32_any)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Any.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_bool)$": {
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_bool_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BoolValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_bytes)$": {
+      "additionalProperties": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_bytes_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BytesValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_double)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "enum": [
+              "NaN",
+              "Infinity",
+              "-Infinity"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_double_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.DoubleValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_duration)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Duration.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_enum)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_float)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "enum": [
+              "NaN",
+              "Infinity",
+              "-Infinity"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_float_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.FloatValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_int32)$": {
+      "additionalProperties": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_int32_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_int64)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_int64_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_list_value)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.ListValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_message)$": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_null_value)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_string)$": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_string_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.StringValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_struct)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Struct.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_timestamp)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Timestamp.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_uint32)$": {
+      "additionalProperties": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_uint32_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_uint64)$": {
+      "additionalProperties": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_uint64_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_value)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int64_any)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Any.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_bool)$": {
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_bool_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BoolValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_bytes)$": {
+      "additionalProperties": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_bytes_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BytesValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_double)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "enum": [
+              "NaN",
+              "Infinity",
+              "-Infinity"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_double_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.DoubleValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_duration)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Duration.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_enum)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_float)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "enum": [
+              "NaN",
+              "Infinity",
+              "-Infinity"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_float_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.FloatValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_int32)$": {
+      "additionalProperties": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_int32_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_int64)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_int64_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_list_value)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.ListValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_message)$": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_nested_type)$": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.NestedTestAllTypes.jsonschema.json"
+      },
+      "description": "Map",
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_null_value)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_string)$": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_string_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.StringValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_struct)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Struct.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_timestamp)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Timestamp.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_uint32)$": {
+      "additionalProperties": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_uint32_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_uint64)$": {
+      "additionalProperties": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_uint64_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_value)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_string_any)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Any.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_bool)$": {
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_bool_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BoolValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_bytes)$": {
+      "additionalProperties": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_bytes_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BytesValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_double)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "enum": [
+              "NaN",
+              "Infinity",
+              "-Infinity"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_double_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.DoubleValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_duration)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Duration.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_enum)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_float)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "enum": [
+              "NaN",
+              "Infinity",
+              "-Infinity"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_float_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.FloatValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_int32)$": {
+      "additionalProperties": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_int32_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_int64)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_int64_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_list_value)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.ListValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_message)$": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_null_value)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_string)$": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_string_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.StringValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_struct)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Struct.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_timestamp)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Timestamp.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_uint32)$": {
+      "additionalProperties": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_uint32_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_uint64)$": {
+      "additionalProperties": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_uint64_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_value)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_any)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Any.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_bool)$": {
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_bool_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BoolValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_bytes)$": {
+      "additionalProperties": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_bytes_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BytesValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_double)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "enum": [
+              "NaN",
+              "Infinity",
+              "-Infinity"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_double_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.DoubleValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_duration)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Duration.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_enum)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_float)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "enum": [
+              "NaN",
+              "Infinity",
+              "-Infinity"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_float_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.FloatValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_int32)$": {
+      "additionalProperties": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_int32_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_int64)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_int64_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_list_value)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.ListValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_message)$": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_null_value)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_string)$": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_string_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.StringValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_struct)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Struct.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_timestamp)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Timestamp.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_uint32)$": {
+      "additionalProperties": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_uint32_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_uint64)$": {
+      "additionalProperties": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_uint64_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_value)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint64_any)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Any.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint64_bool)$": {
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint64_bool_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BoolValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint64_bytes)$": {
+      "additionalProperties": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint64_bytes_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BytesValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint64_double)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "enum": [
+              "NaN",
+              "Infinity",
+              "-Infinity"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint64_double_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.DoubleValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint64_duration)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Duration.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint64_enum)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint64_float)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "enum": [
+              "NaN",
+              "Infinity",
+              "-Infinity"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint64_float_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.FloatValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint64_int32)$": {
+      "additionalProperties": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint64_int32_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint64_int64)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint64_int64_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint64_list_value)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.ListValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint64_message)$": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint64_null_value)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint64_string)$": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint64_string_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.StringValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint64_struct)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Struct.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint64_timestamp)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Timestamp.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint64_uint32)$": {
+      "additionalProperties": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint64_uint32_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint64_uint64)$": {
+      "additionalProperties": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint64_uint64_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint64_value)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(null_value)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "NULL_VALUE"
+          ],
+          "title": "Null Value",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "^(optional_null_value)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "NULL_VALUE"
+          ],
+          "title": "Null Value",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "^(repeated_any)$": {
+      "description": "Repeated wellknown.",
+      "items": {
+        "$ref": "google.protobuf.Any.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "^(repeated_bool)$": {
+      "items": {
+        "type": "boolean"
+      },
+      "type": "array"
+    },
+    "^(repeated_bool_wrapper)$": {
+      "items": {
+        "$ref": "google.protobuf.BoolValue.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "^(repeated_bytes)$": {
+      "items": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "^(repeated_bytes_wrapper)$": {
+      "items": {
+        "$ref": "google.protobuf.BytesValue.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "^(repeated_cord)$": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "^(repeated_double)$": {
+      "items": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "enum": [
+              "NaN",
+              "Infinity",
+              "-Infinity"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "^(repeated_double_wrapper)$": {
+      "items": {
+        "$ref": "google.protobuf.DoubleValue.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "^(repeated_duration)$": {
+      "items": {
+        "$ref": "google.protobuf.Duration.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "^(repeated_fixed32)$": {
+      "items": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "^(repeated_fixed64)$": {
+      "items": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "^(repeated_float)$": {
+      "items": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "enum": [
+              "NaN",
+              "Infinity",
+              "-Infinity"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "^(repeated_float_wrapper)$": {
+      "items": {
+        "$ref": "google.protobuf.FloatValue.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "^(repeated_int32)$": {
+      "description": "Repeated",
+      "items": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "^(repeated_int32_wrapper)$": {
+      "items": {
+        "$ref": "google.protobuf.Int32Value.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "^(repeated_int64)$": {
+      "items": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "^(repeated_int64_wrapper)$": {
+      "items": {
+        "$ref": "google.protobuf.Int64Value.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "^(repeated_lazy_message)$": {
+      "items": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "^(repeated_list_value)$": {
+      "items": {
+        "$ref": "google.protobuf.ListValue.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "^(repeated_nested_enum)$": {
+      "items": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "^(repeated_nested_message)$": {
+      "description": "Repeated and nested",
+      "items": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "^(repeated_null_value)$": {
+      "items": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "^(repeated_sfixed32)$": {
+      "items": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "^(repeated_sfixed64)$": {
+      "items": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "^(repeated_sint32)$": {
+      "items": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "^(repeated_sint64)$": {
+      "items": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "^(repeated_string)$": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "^(repeated_string_piece)$": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "^(repeated_string_wrapper)$": {
+      "items": {
+        "$ref": "google.protobuf.StringValue.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "^(repeated_struct)$": {
+      "items": {
+        "$ref": "google.protobuf.Struct.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "^(repeated_timestamp)$": {
+      "items": {
+        "$ref": "google.protobuf.Timestamp.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "^(repeated_uint32)$": {
+      "items": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "^(repeated_uint32_wrapper)$": {
+      "items": {
+        "$ref": "google.protobuf.UInt32Value.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "^(repeated_uint64)$": {
+      "items": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "^(repeated_uint64_wrapper)$": {
+      "items": {
+        "$ref": "google.protobuf.UInt64Value.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "^(repeated_value)$": {
+      "items": {
+        "$ref": "google.protobuf.Value.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "^(single_any)$": {
+      "$ref": "google.protobuf.Any.jsonschema.json",
+      "description": "Wellknown."
+    },
+    "^(single_bool)$": {
+      "type": "boolean"
+    },
+    "^(single_bool_wrapper)$": {
+      "$ref": "google.protobuf.BoolValue.jsonschema.json"
+    },
+    "^(single_bytes)$": {
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "^(single_bytes_wrapper)$": {
+      "$ref": "google.protobuf.BytesValue.jsonschema.json"
+    },
+    "^(single_double)$": {
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "enum": [
+            "NaN",
+            "Infinity",
+            "-Infinity"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "^(single_double_wrapper)$": {
+      "$ref": "google.protobuf.DoubleValue.jsonschema.json"
+    },
+    "^(single_duration)$": {
+      "$ref": "google.protobuf.Duration.jsonschema.json"
+    },
+    "^(single_fixed32)$": {
+      "exclusiveMaximum": 4294967296,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "^(single_fixed64)$": {
+      "exclusiveMaximum": 18446744073709552000,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "^(single_float)$": {
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "enum": [
+            "NaN",
+            "Infinity",
+            "-Infinity"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "^(single_float_wrapper)$": {
+      "$ref": "google.protobuf.FloatValue.jsonschema.json"
+    },
+    "^(single_int32)$": {
+      "description": "Singular",
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(single_int32_wrapper)$": {
+      "$ref": "google.protobuf.Int32Value.jsonschema.json"
+    },
+    "^(single_int64)$": {
+      "anyOf": [
+        {
+          "maximum": 9223372036854776000,
+          "minimum": -9223372036854776000,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(single_int64_wrapper)$": {
+      "$ref": "google.protobuf.Int64Value.jsonschema.json"
+    },
+    "^(single_nested_enum)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "FOO",
+            "BAR",
+            "BAZ"
+          ],
+          "title": "Nested Enum",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "^(single_nested_message)$": {
+      "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+    },
+    "^(single_sfixed32)$": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(single_sfixed64)$": {
+      "anyOf": [
+        {
+          "maximum": 9223372036854776000,
+          "minimum": -9223372036854776000,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(single_sint32)$": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(single_sint64)$": {
+      "anyOf": [
+        {
+          "maximum": 9223372036854776000,
+          "minimum": -9223372036854776000,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(single_string)$": {
+      "type": "string"
+    },
+    "^(single_string_wrapper)$": {
+      "$ref": "google.protobuf.StringValue.jsonschema.json"
+    },
+    "^(single_struct)$": {
+      "$ref": "google.protobuf.Struct.jsonschema.json"
+    },
+    "^(single_timestamp)$": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "^(single_uint32)$": {
+      "exclusiveMaximum": 4294967296,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "^(single_uint32_wrapper)$": {
+      "$ref": "google.protobuf.UInt32Value.jsonschema.json"
+    },
+    "^(single_uint64)$": {
+      "exclusiveMaximum": 18446744073709552000,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "^(single_uint64_wrapper)$": {
+      "$ref": "google.protobuf.UInt64Value.jsonschema.json"
+    },
+    "^(single_value)$": {
+      "$ref": "google.protobuf.Value.jsonschema.json"
+    },
+    "^(standalone_enum)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "FOO",
+            "BAR",
+            "BAZ"
+          ],
+          "title": "Nested Enum",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "^(standalone_message)$": {
+      "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+    }
+  },
+  "properties": {
+    "listValue": {
+      "$ref": "google.protobuf.ListValue.jsonschema.json"
+    },
+    "mapBoolAny": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Any.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolBool": {
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolBoolWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BoolValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolBytes": {
+      "additionalProperties": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolBytesWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BytesValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolDouble": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "enum": [
+              "NaN",
+              "Infinity",
+              "-Infinity"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolDoubleWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.DoubleValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolDuration": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Duration.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolEnum": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolFloat": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "enum": [
+              "NaN",
+              "Infinity",
+              "-Infinity"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolFloatWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.FloatValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolInt32": {
+      "additionalProperties": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolInt32Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolInt64": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolInt64Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolListValue": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.ListValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolMessage": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolNullValue": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolString": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolStringWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.StringValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolStruct": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Struct.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolTimestamp": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Timestamp.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolUint32": {
+      "additionalProperties": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolUint32Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolUint64": {
+      "additionalProperties": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolUint64Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolValue": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapInt32Any": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Any.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32Bool": {
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32BoolWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BoolValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32Bytes": {
+      "additionalProperties": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32BytesWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BytesValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32Double": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "enum": [
+              "NaN",
+              "Infinity",
+              "-Infinity"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32DoubleWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.DoubleValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32Duration": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Duration.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32Enum": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32Float": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "enum": [
+              "NaN",
+              "Infinity",
+              "-Infinity"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32FloatWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.FloatValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32Int32": {
+      "additionalProperties": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32Int32Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32Int64": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32Int64Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32ListValue": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.ListValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32Message": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32NullValue": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32String": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32StringWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.StringValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32Struct": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Struct.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32Timestamp": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Timestamp.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32Uint32": {
+      "additionalProperties": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32Uint32Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32Uint64": {
+      "additionalProperties": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32Uint64Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32Value": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt64Any": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Any.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64Bool": {
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64BoolWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BoolValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64Bytes": {
+      "additionalProperties": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64BytesWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BytesValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64Double": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "enum": [
+              "NaN",
+              "Infinity",
+              "-Infinity"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64DoubleWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.DoubleValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64Duration": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Duration.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64Enum": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64Float": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "enum": [
+              "NaN",
+              "Infinity",
+              "-Infinity"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64FloatWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.FloatValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64Int32": {
+      "additionalProperties": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64Int32Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64Int64": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64Int64Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64ListValue": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.ListValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64Message": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64NestedType": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.NestedTestAllTypes.jsonschema.json"
+      },
+      "description": "Map",
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64NullValue": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64String": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64StringWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.StringValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64Struct": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Struct.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64Timestamp": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Timestamp.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64Uint32": {
+      "additionalProperties": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64Uint32Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64Uint64": {
+      "additionalProperties": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64Uint64Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64Value": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapStringAny": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Any.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringBool": {
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringBoolWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BoolValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringBytes": {
+      "additionalProperties": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringBytesWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BytesValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringDouble": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "enum": [
+              "NaN",
+              "Infinity",
+              "-Infinity"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringDoubleWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.DoubleValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringDuration": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Duration.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringEnum": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringFloat": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "enum": [
+              "NaN",
+              "Infinity",
+              "-Infinity"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringFloatWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.FloatValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringInt32": {
+      "additionalProperties": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringInt32Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringInt64": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringInt64Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringListValue": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.ListValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringMessage": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringNullValue": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringString": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringStringWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.StringValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringStruct": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Struct.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringTimestamp": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Timestamp.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringUint32": {
+      "additionalProperties": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringUint32Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringUint64": {
+      "additionalProperties": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringUint64Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringValue": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapUint32Any": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Any.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32Bool": {
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32BoolWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BoolValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32Bytes": {
+      "additionalProperties": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32BytesWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BytesValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32Double": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "enum": [
+              "NaN",
+              "Infinity",
+              "-Infinity"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32DoubleWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.DoubleValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32Duration": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Duration.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32Enum": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32Float": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "enum": [
+              "NaN",
+              "Infinity",
+              "-Infinity"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32FloatWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.FloatValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32Int32": {
+      "additionalProperties": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32Int32Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32Int64": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32Int64Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32ListValue": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.ListValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32Message": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32NullValue": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32String": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32StringWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.StringValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32Struct": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Struct.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32Timestamp": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Timestamp.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32Uint32": {
+      "additionalProperties": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32Uint32Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32Uint64": {
+      "additionalProperties": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32Uint64Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32Value": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint64Any": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Any.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint64Bool": {
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint64BoolWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BoolValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint64Bytes": {
+      "additionalProperties": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint64BytesWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BytesValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint64Double": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "enum": [
+              "NaN",
+              "Infinity",
+              "-Infinity"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint64DoubleWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.DoubleValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint64Duration": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Duration.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint64Enum": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint64Float": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "enum": [
+              "NaN",
+              "Infinity",
+              "-Infinity"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint64FloatWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.FloatValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint64Int32": {
+      "additionalProperties": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint64Int32Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint64Int64": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint64Int64Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint64ListValue": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.ListValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint64Message": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint64NullValue": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint64String": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint64StringWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.StringValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint64Struct": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Struct.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint64Timestamp": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Timestamp.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint64Uint32": {
+      "additionalProperties": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint64Uint32Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint64Uint64": {
+      "additionalProperties": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint64Uint64Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint64Value": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "nullValue": {
+      "anyOf": [
+        {
+          "enum": [
+            "NULL_VALUE"
+          ],
+          "title": "Null Value",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "optionalNullValue": {
+      "anyOf": [
+        {
+          "enum": [
+            "NULL_VALUE"
+          ],
+          "title": "Null Value",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "repeatedAny": {
+      "description": "Repeated wellknown.",
+      "items": {
+        "$ref": "google.protobuf.Any.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "repeatedBool": {
+      "items": {
+        "type": "boolean"
+      },
+      "type": "array"
+    },
+    "repeatedBoolWrapper": {
+      "items": {
+        "$ref": "google.protobuf.BoolValue.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "repeatedBytes": {
+      "items": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "repeatedBytesWrapper": {
+      "items": {
+        "$ref": "google.protobuf.BytesValue.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "repeatedCord": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "repeatedDouble": {
+      "items": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "enum": [
+              "NaN",
+              "Infinity",
+              "-Infinity"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "repeatedDoubleWrapper": {
+      "items": {
+        "$ref": "google.protobuf.DoubleValue.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "repeatedDuration": {
+      "items": {
+        "$ref": "google.protobuf.Duration.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "repeatedFixed32": {
+      "items": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "repeatedFixed64": {
+      "items": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "repeatedFloat": {
+      "items": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "enum": [
+              "NaN",
+              "Infinity",
+              "-Infinity"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "repeatedFloatWrapper": {
+      "items": {
+        "$ref": "google.protobuf.FloatValue.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "repeatedInt32": {
+      "description": "Repeated",
+      "items": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "repeatedInt32Wrapper": {
+      "items": {
+        "$ref": "google.protobuf.Int32Value.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "repeatedInt64": {
+      "items": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "repeatedInt64Wrapper": {
+      "items": {
+        "$ref": "google.protobuf.Int64Value.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "repeatedLazyMessage": {
+      "items": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "repeatedListValue": {
+      "items": {
+        "$ref": "google.protobuf.ListValue.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "repeatedNestedEnum": {
+      "items": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "repeatedNestedMessage": {
+      "description": "Repeated and nested",
+      "items": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "repeatedNullValue": {
+      "items": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "repeatedSfixed32": {
+      "items": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "repeatedSfixed64": {
+      "items": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "repeatedSint32": {
+      "items": {
+        "exclusiveMaximum": 2147483648,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "repeatedSint64": {
+      "items": {
+        "anyOf": [
+          {
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "repeatedString": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "repeatedStringPiece": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "repeatedStringWrapper": {
+      "items": {
+        "$ref": "google.protobuf.StringValue.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "repeatedStruct": {
+      "items": {
+        "$ref": "google.protobuf.Struct.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "repeatedTimestamp": {
+      "items": {
+        "$ref": "google.protobuf.Timestamp.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "repeatedUint32": {
+      "items": {
+        "exclusiveMaximum": 4294967296,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "repeatedUint32Wrapper": {
+      "items": {
+        "$ref": "google.protobuf.UInt32Value.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "repeatedUint64": {
+      "items": {
+        "exclusiveMaximum": 18446744073709552000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "repeatedUint64Wrapper": {
+      "items": {
+        "$ref": "google.protobuf.UInt64Value.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "repeatedValue": {
+      "items": {
+        "$ref": "google.protobuf.Value.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "singleAny": {
+      "$ref": "google.protobuf.Any.jsonschema.json",
+      "description": "Wellknown."
+    },
+    "singleBool": {
+      "type": "boolean"
+    },
+    "singleBoolWrapper": {
+      "$ref": "google.protobuf.BoolValue.jsonschema.json"
+    },
+    "singleBytes": {
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "singleBytesWrapper": {
+      "$ref": "google.protobuf.BytesValue.jsonschema.json"
+    },
+    "singleDouble": {
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "enum": [
+            "NaN",
+            "Infinity",
+            "-Infinity"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "singleDoubleWrapper": {
+      "$ref": "google.protobuf.DoubleValue.jsonschema.json"
+    },
+    "singleDuration": {
+      "$ref": "google.protobuf.Duration.jsonschema.json"
+    },
+    "singleFixed32": {
+      "exclusiveMaximum": 4294967296,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "singleFixed64": {
+      "exclusiveMaximum": 18446744073709552000,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "singleFloat": {
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "enum": [
+            "NaN",
+            "Infinity",
+            "-Infinity"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "singleFloatWrapper": {
+      "$ref": "google.protobuf.FloatValue.jsonschema.json"
+    },
+    "singleInt32": {
+      "description": "Singular",
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "singleInt32Wrapper": {
+      "$ref": "google.protobuf.Int32Value.jsonschema.json"
+    },
+    "singleInt64": {
+      "anyOf": [
+        {
+          "maximum": 9223372036854776000,
+          "minimum": -9223372036854776000,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "singleInt64Wrapper": {
+      "$ref": "google.protobuf.Int64Value.jsonschema.json"
+    },
+    "singleNestedEnum": {
+      "anyOf": [
+        {
+          "enum": [
+            "FOO",
+            "BAR",
+            "BAZ"
+          ],
+          "title": "Nested Enum",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "singleNestedMessage": {
+      "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+    },
+    "singleSfixed32": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "singleSfixed64": {
+      "anyOf": [
+        {
+          "maximum": 9223372036854776000,
+          "minimum": -9223372036854776000,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "singleSint32": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "singleSint64": {
+      "anyOf": [
+        {
+          "maximum": 9223372036854776000,
+          "minimum": -9223372036854776000,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "singleString": {
+      "type": "string"
+    },
+    "singleStringWrapper": {
+      "$ref": "google.protobuf.StringValue.jsonschema.json"
+    },
+    "singleStruct": {
+      "$ref": "google.protobuf.Struct.jsonschema.json"
+    },
+    "singleTimestamp": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "singleUint32": {
+      "exclusiveMaximum": 4294967296,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "singleUint32Wrapper": {
+      "$ref": "google.protobuf.UInt32Value.jsonschema.json"
+    },
+    "singleUint64": {
+      "exclusiveMaximum": 18446744073709552000,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "singleUint64Wrapper": {
+      "$ref": "google.protobuf.UInt64Value.jsonschema.json"
+    },
+    "singleValue": {
+      "$ref": "google.protobuf.Value.jsonschema.json"
+    },
+    "standaloneEnum": {
+      "anyOf": [
+        {
+          "enum": [
+            "FOO",
+            "BAR",
+            "BAZ"
+          ],
+          "title": "Nested Enum",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "standaloneMessage": {
+      "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+    }
+  },
+  "title": "Test All Types",
+  "type": "object"
+}

--- a/internal/testdata/jsonschema/google.protobuf.Any.jsonschema.json
+++ b/internal/testdata/jsonschema/google.protobuf.Any.jsonschema.json
@@ -1,0 +1,11 @@
+{
+  "$id": "google.protobuf.Any.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "@type": {
+      "type": "string"
+    }
+  },
+  "title": "Any",
+  "type": "object"
+}

--- a/internal/testdata/jsonschema/google.protobuf.BoolValue.jsonschema.json
+++ b/internal/testdata/jsonschema/google.protobuf.BoolValue.jsonschema.json
@@ -1,0 +1,7 @@
+{
+  "$id": "google.protobuf.BoolValue.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The bool value.",
+  "title": "Bool Value",
+  "type": "boolean"
+}

--- a/internal/testdata/jsonschema/google.protobuf.BytesValue.jsonschema.json
+++ b/internal/testdata/jsonschema/google.protobuf.BytesValue.jsonschema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "google.protobuf.BytesValue.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The bytes value.",
+  "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+  "title": "Bytes Value",
+  "type": "string"
+}

--- a/internal/testdata/jsonschema/google.protobuf.DoubleValue.jsonschema.json
+++ b/internal/testdata/jsonschema/google.protobuf.DoubleValue.jsonschema.json
@@ -1,0 +1,22 @@
+{
+  "$id": "google.protobuf.DoubleValue.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "anyOf": [
+    {
+      "type": "number"
+    },
+    {
+      "type": "string"
+    },
+    {
+      "enum": [
+        "NaN",
+        "Infinity",
+        "-Infinity"
+      ],
+      "type": "string"
+    }
+  ],
+  "description": "The double value.",
+  "title": "Double Value"
+}

--- a/internal/testdata/jsonschema/google.protobuf.Duration.jsonschema.json
+++ b/internal/testdata/jsonschema/google.protobuf.Duration.jsonschema.json
@@ -1,0 +1,7 @@
+{
+  "$id": "google.protobuf.Duration.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "format": "duration",
+  "title": "Duration",
+  "type": "string"
+}

--- a/internal/testdata/jsonschema/google.protobuf.FloatValue.jsonschema.json
+++ b/internal/testdata/jsonschema/google.protobuf.FloatValue.jsonschema.json
@@ -1,0 +1,22 @@
+{
+  "$id": "google.protobuf.FloatValue.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "anyOf": [
+    {
+      "type": "number"
+    },
+    {
+      "type": "string"
+    },
+    {
+      "enum": [
+        "NaN",
+        "Infinity",
+        "-Infinity"
+      ],
+      "type": "string"
+    }
+  ],
+  "description": "The float value.",
+  "title": "Float Value"
+}

--- a/internal/testdata/jsonschema/google.protobuf.Int32Value.jsonschema.json
+++ b/internal/testdata/jsonschema/google.protobuf.Int32Value.jsonschema.json
@@ -1,0 +1,9 @@
+{
+  "$id": "google.protobuf.Int32Value.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The int32 value.",
+  "exclusiveMaximum": 2147483648,
+  "minimum": -2147483648,
+  "title": "Int32 Value",
+  "type": "integer"
+}

--- a/internal/testdata/jsonschema/google.protobuf.Int64Value.jsonschema.json
+++ b/internal/testdata/jsonschema/google.protobuf.Int64Value.jsonschema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "google.protobuf.Int64Value.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "anyOf": [
+    {
+      "maximum": 9223372036854776000,
+      "minimum": -9223372036854776000,
+      "type": "integer"
+    },
+    {
+      "pattern": "^[0-9]+$",
+      "type": "string"
+    }
+  ],
+  "description": "The int64 value.",
+  "title": "Int64 Value"
+}

--- a/internal/testdata/jsonschema/google.protobuf.ListValue.jsonschema.json
+++ b/internal/testdata/jsonschema/google.protobuf.ListValue.jsonschema.json
@@ -1,0 +1,6 @@
+{
+  "$id": "google.protobuf.ListValue.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "List Value",
+  "type": "array"
+}

--- a/internal/testdata/jsonschema/google.protobuf.StringValue.jsonschema.json
+++ b/internal/testdata/jsonschema/google.protobuf.StringValue.jsonschema.json
@@ -1,0 +1,7 @@
+{
+  "$id": "google.protobuf.StringValue.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The string value.",
+  "title": "String Value",
+  "type": "string"
+}

--- a/internal/testdata/jsonschema/google.protobuf.Struct.jsonschema.json
+++ b/internal/testdata/jsonschema/google.protobuf.Struct.jsonschema.json
@@ -1,0 +1,6 @@
+{
+  "$id": "google.protobuf.Struct.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Struct",
+  "type": "object"
+}

--- a/internal/testdata/jsonschema/google.protobuf.Timestamp.jsonschema.json
+++ b/internal/testdata/jsonschema/google.protobuf.Timestamp.jsonschema.json
@@ -1,0 +1,7 @@
+{
+  "$id": "google.protobuf.Timestamp.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "format": "date-time",
+  "title": "Timestamp",
+  "type": "string"
+}

--- a/internal/testdata/jsonschema/google.protobuf.UInt32Value.jsonschema.json
+++ b/internal/testdata/jsonschema/google.protobuf.UInt32Value.jsonschema.json
@@ -1,0 +1,9 @@
+{
+  "$id": "google.protobuf.UInt32Value.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The uint32 value.",
+  "exclusiveMaximum": 4294967296,
+  "minimum": 0,
+  "title": "U Int32 Value",
+  "type": "integer"
+}

--- a/internal/testdata/jsonschema/google.protobuf.UInt64Value.jsonschema.json
+++ b/internal/testdata/jsonschema/google.protobuf.UInt64Value.jsonschema.json
@@ -1,0 +1,9 @@
+{
+  "$id": "google.protobuf.UInt64Value.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The uint64 value.",
+  "exclusiveMaximum": 18446744073709552000,
+  "minimum": 0,
+  "title": "U Int64 Value",
+  "type": "integer"
+}

--- a/internal/testdata/jsonschema/google.protobuf.Value.jsonschema.json
+++ b/internal/testdata/jsonschema/google.protobuf.Value.jsonschema.json
@@ -1,0 +1,5 @@
+{
+  "$id": "google.protobuf.Value.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Value"
+}


### PR DESCRIPTION
To use the JSON name as the primary name, reference the `*.jsonschema.json` file (instead of the `*.schema.json` file).
This is the name that IDEs use for auto-complete