### PR TITLE
Update go and golangci-lint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.22.x]
+        go-version: [1.22.x, 1.23.x]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -32,5 +32,5 @@ jobs:
         # conflicting guidance, run only on the most recent supported version.
         # For the same reason, only check generated code on the most recent
         # supported version.
-        if: matrix.go-version == '1.22.x'
+        if: matrix.go-version == '1.23.x'
         run: make checkgenerate && make lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,3 @@
-run:
-  skip-dirs-use-default: false
 linters-settings:
   gocyclo:
     min-complexity: 25
@@ -26,36 +24,29 @@ linters:
   enable-all: true
   disable:
     - cyclop            # covered by gocyclo
-    - deadcode          # abandoned
     - depguard
     - exhaustive
-    - exhaustivestruct  # replaced by exhaustruct
+    - execinquery       # deprecated in golangci v1.58 
     - exhaustruct
     - funlen            # rely on code review to limit function length
     - gochecknoglobals  # globals are fine
     - gocognit          # dubious "cognitive overhead" quantification
     - gofumpt           # prefer standard gofmt
     - goimports         # rely on gci instead
-    - golint            # deprecated by Go team
-    - gomnd             # some unnamed constants are okay
-    - ifshort           # deprecated by author
-    - interfacer        # deprecated by author
+    - gomnd             # deprecated in golangci v1.58 in favor of mnd
+    - mnd               # some unnamed constants are okay
     - ireturn           # "accept interfaces, return structs" isn't ironclad
     - lll               # don't want hard limits for line length
     - maintidx          # covered by gocyclo
-    - maligned          # readability trumps efficient struct packing
     - nilnil
     - nlreturn          # generous whitespace violates house style
-    - nosnakecase       # deprecated in https://github.com/golangci/golangci-lint/pull/3065
     - protogetter
-    - scopelint         # deprecated by author
-    - structcheck       # abandoned
     - testpackage       # internal tests are fine
-    - varcheck          # abandoned
     - wrapcheck         # don't _always_ need to wrap errors
     - wsl               # generous whitespace violates house style
 issues:
+  exclude-dirs-use-default: false
   exclude:
     # Don't ban use of fmt.Errorf to create new errors, but the remaining
     # checks from err113 are useful.
-    - "err113: do not define dynamic errors.*"
+    - "do not define dynamic errors.*"

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ $(BIN)/license-header: $(BIN) Makefile
 	go install github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@latest
 
 $(BIN)/golangci-lint: $(BIN) Makefile
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.57.1
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.0
 
 $(BIN)/jv: $(BIN) Makefile
 	go install github.com/santhosh-tekuri/jsonschema/cmd/jv@latest

--- a/internal/protoschema/jsonschema/jsonschema.go
+++ b/internal/protoschema/jsonschema/jsonschema.go
@@ -231,15 +231,15 @@ func (p *jsonSchemaGenerator) generateEnumValidation(field protoreflect.FieldDes
 
 func (p *jsonSchemaGenerator) generateIntValidation(_ protoreflect.FieldDescriptor, entry map[string]interface{}, bitSize int) {
 	// Use floats to handle integer overflow.
-	minBitSize := -math.Pow(2, float64(bitSize-1))
-	maxBitSize := math.Pow(2, float64(bitSize-1))
+	minSize := -math.Pow(2, float64(bitSize-1))
+	maxSize := math.Pow(2, float64(bitSize-1))
 	if bitSize <= 53 {
 		entry["type"] = jsInteger
-		entry["minimum"] = minBitSize
-		entry["exclusiveMaximum"] = maxBitSize
+		entry["minimum"] = minSize
+		entry["exclusiveMaximum"] = maxSize
 	} else {
 		entry["anyOf"] = []map[string]interface{}{
-			{"type": jsInteger, "minimum": minBitSize, "maximum": maxBitSize},
+			{"type": jsInteger, "minimum": minSize, "maximum": maxSize},
 			{"type": jsString, "pattern": "^[0-9]+$"},
 		}
 	}

--- a/internal/protoschema/jsonschema/jsonschema.go
+++ b/internal/protoschema/jsonschema/jsonschema.go
@@ -231,15 +231,15 @@ func (p *jsonSchemaGenerator) generateEnumValidation(field protoreflect.FieldDes
 
 func (p *jsonSchemaGenerator) generateIntValidation(_ protoreflect.FieldDescriptor, entry map[string]interface{}, bitSize int) {
 	// Use floats to handle integer overflow.
-	min := -math.Pow(2, float64(bitSize-1))
-	max := math.Pow(2, float64(bitSize-1))
+	minBitSize := -math.Pow(2, float64(bitSize-1))
+	maxBitSize := math.Pow(2, float64(bitSize-1))
 	if bitSize <= 53 {
 		entry["type"] = jsInteger
-		entry["minimum"] = min
-		entry["exclusiveMaximum"] = max
+		entry["minimum"] = minBitSize
+		entry["exclusiveMaximum"] = maxBitSize
 	} else {
 		entry["anyOf"] = []map[string]interface{}{
-			{"type": jsInteger, "minimum": min, "maximum": max},
+			{"type": jsInteger, "minimum": minBitSize, "maximum": maxBitSize},
 			{"type": jsString, "pattern": "^[0-9]+$"},
 		}
 	}


### PR DESCRIPTION
Now that a new version of Go has been released, this bumps the versions used in this repo.

This also updates golangci-lint to the latest, which called for some config changes to eliminate warnings.