### PR TITLE
Support editions

### DIFF
--- a/internal/protoschema/plugin/pluginjsonschema/pluginjsonschema.go
+++ b/internal/protoschema/plugin/pluginjsonschema/pluginjsonschema.go
@@ -22,6 +22,7 @@ import (
 	"github.com/bufbuild/protoplugin"
 	"github.com/bufbuild/protoschema-plugins/internal/protoschema/jsonschema"
 	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/descriptorpb"
 )
 
 // Handle implements protoplugin.Handler and is the main entry point for the plugin.
@@ -51,6 +52,7 @@ func Handle(
 	}
 
 	responseWriter.SetFeatureProto3Optional()
+	responseWriter.SetFeatureSupportsEditions(descriptorpb.Edition_EDITION_2023, descriptorpb.Edition_EDITION_2023)
 	return nil
 }
 

--- a/internal/protoschema/plugin/pluginpubsub/pluginpubsub.go
+++ b/internal/protoschema/plugin/pluginpubsub/pluginpubsub.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/bufbuild/protoplugin"
 	"github.com/bufbuild/protoschema-plugins/internal/protoschema/pubsub"
+	"google.golang.org/protobuf/types/descriptorpb"
 )
 
 // Handle implements protoplugin.Handler and is the main entry point for the plugin.
@@ -48,5 +49,6 @@ func Handle(
 	}
 
 	responseWriter.SetFeatureProto3Optional()
+	responseWriter.SetFeatureSupportsEditions(descriptorpb.Edition_EDITION_2023, descriptorpb.Edition_EDITION_2023)
 	return nil
 }

--- a/internal/protoschema/pubsub/pubsub.go
+++ b/internal/protoschema/pubsub/pubsub.go
@@ -37,7 +37,10 @@ func Generate(input protoreflect.MessageDescriptor) (string, error) {
 		return "", err
 	}
 	file := &descriptorpb.FileDescriptorProto{
-		Name:   proto.String(FileExtension),
+		Name: proto.String(FileExtension),
+		// TODO: If/when Pub/Bub schemas support editions, use Edition 2023 so
+		//       there is no loss of fidelity for syntax-specific semantics
+		//       (such as field presence).
 		Syntax: proto.String("proto2"),
 		MessageType: []*descriptorpb.DescriptorProto{
 			rootMsg,


### PR DESCRIPTION
The `Syntax()` method of `protoreflect.FileDescriptor` was only examined in one place, and I've fixed that. Everything else uses the other "semantic accessors" of the descriptor interfaces, which means it will work with Editions descriptors, too.

So this enables the plugins to work with source files that use editions.

I left a TODO for updating the pubsub plugin to emit an Editions descriptor. I don't know if Cloud Pub/Sub yet supports that for defining a schema (maybe probably?). But when it does, that will be a better match for normalization since it can correctly model elements with syntax-specific semantics of either/both syntaxes, even mixed in the same file. (Not that Cloud Pub/Sub cares about all of those semantics, but it would then make the `Normalize` capability more broadly and generically useful.)