### PR TITLE
Fix exclusiveMaximum for int64/uint64 types

### DIFF
--- a/internal/protoschema/golden/golden.go
+++ b/internal/protoschema/golden/golden.go
@@ -16,7 +16,6 @@ package golden
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 
@@ -68,17 +67,7 @@ func GetTestDescriptors(testdataPath string) ([]protoreflect.MessageDescriptor, 
 
 // CheckGolden checks the golden file exists and matches the given data.
 func CheckGolden(filePath string, data string) error {
-	if _, err := os.Stat(filePath); err != nil {
-		return err
-	}
-
-	file, err := os.Open(filePath)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	actualBytes, err := io.ReadAll(file)
+	actualBytes, err := os.ReadFile(filePath)
 	if err != nil {
 		return err
 	}

--- a/internal/protoschema/jsonschema/jsonschema.go
+++ b/internal/protoschema/jsonschema/jsonschema.go
@@ -17,6 +17,7 @@ package jsonschema
 import (
 	"fmt"
 	"math"
+	"math/big"
 	"slices"
 	"strings"
 	"unicode"
@@ -43,6 +44,10 @@ const (
 	FieldVisible FieldVisibility = iota
 	FieldHide
 	FieldIgnore
+)
+
+var (
+	exclusiveMaxUint64 = big.NewInt(0).Exp(big.NewInt(2), big.NewInt(64), nil)
 )
 
 type GeneratorOption func(*jsonSchemaGenerator)
@@ -446,7 +451,7 @@ func (p *jsonSchemaGenerator) generateInt64Validation(_ protoreflect.FieldDescri
 	switch {
 	default:
 		schema["anyOf"] = []map[string]interface{}{
-			{"type": jsInteger, "minimum": math.MinInt64, "exclusiveMaximum": math.Pow(2, 63)},
+			{"type": jsInteger, "minimum": math.MinInt64, "exclusiveMaximum": uint64(math.MaxInt64) + 1},
 			{"type": jsString, "pattern": "^-?[0-9]+$"},
 		}
 	case constraints.GetInt64() != nil:
@@ -548,7 +553,7 @@ func (p *jsonSchemaGenerator) generateUint64Validation(_ protoreflect.FieldDescr
 	switch {
 	default:
 		schema["anyOf"] = []map[string]interface{}{
-			{"type": jsInteger, "minimum": 0, "exclusiveMaximum": float64(uint64(1)<<63) * 2},
+			{"type": jsInteger, "minimum": 0, "exclusiveMaximum": exclusiveMaxUint64},
 			{"type": jsString, "pattern": "^[0-9]+$"},
 		}
 	case constraints.GetUint64() != nil:

--- a/internal/testdata/jsonschema/bufext.cel.expr.conformance.proto3.TestAllTypes.jsonschema.json
+++ b/internal/testdata/jsonschema/bufext.cel.expr.conformance.proto3.TestAllTypes.jsonschema.json
@@ -178,7 +178,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -302,7 +302,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -532,7 +532,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -678,7 +678,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -724,7 +724,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -743,7 +743,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -762,7 +762,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -782,7 +782,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -801,7 +801,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -835,7 +835,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -854,7 +854,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -873,7 +873,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -907,7 +907,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -943,7 +943,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -962,7 +962,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -983,7 +983,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -1002,7 +1002,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -1018,7 +1018,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -1031,7 +1031,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -1050,7 +1050,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -1069,7 +1069,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -1088,7 +1088,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -1108,7 +1108,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -1140,7 +1140,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -1159,7 +1159,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -1178,7 +1178,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -1197,7 +1197,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -1216,7 +1216,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -1237,7 +1237,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -1256,7 +1256,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -1272,7 +1272,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -1285,7 +1285,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -1304,7 +1304,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -1323,7 +1323,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -1506,7 +1506,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -1630,7 +1630,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -1860,7 +1860,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -2006,7 +2006,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2052,7 +2052,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2071,7 +2071,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2090,7 +2090,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2110,7 +2110,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2129,7 +2129,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2163,7 +2163,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2182,7 +2182,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2201,7 +2201,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2235,7 +2235,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2271,7 +2271,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2290,7 +2290,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2311,7 +2311,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2330,7 +2330,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2346,7 +2346,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -2359,7 +2359,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2378,7 +2378,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2397,7 +2397,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2416,7 +2416,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2448,7 +2448,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2467,7 +2467,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2486,7 +2486,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2505,7 +2505,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2524,7 +2524,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2545,7 +2545,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2564,7 +2564,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2580,7 +2580,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2593,7 +2593,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2612,7 +2612,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2631,7 +2631,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2758,7 +2758,7 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2818,7 +2818,7 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -2907,7 +2907,7 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -2931,7 +2931,7 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -2991,7 +2991,7 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -3064,7 +3064,7 @@
     "^(single_fixed64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 18446744073709552000,
+          "exclusiveMaximum": 18446744073709551616,
           "minimum": 0,
           "type": "integer"
         },
@@ -3109,7 +3109,7 @@
     "^(single_int64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854776000,
+          "exclusiveMaximum": 9223372036854775808,
           "minimum": -9223372036854775808,
           "type": "integer"
         },
@@ -3151,7 +3151,7 @@
     "^(single_sfixed64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854776000,
+          "exclusiveMaximum": 9223372036854775808,
           "minimum": -9223372036854775808,
           "type": "integer"
         },
@@ -3169,7 +3169,7 @@
     "^(single_sint64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854776000,
+          "exclusiveMaximum": 9223372036854775808,
           "minimum": -9223372036854775808,
           "type": "integer"
         },
@@ -3202,7 +3202,7 @@
     "^(single_uint64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 18446744073709552000,
+          "exclusiveMaximum": 18446744073709551616,
           "minimum": 0,
           "type": "integer"
         },
@@ -3415,7 +3415,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -3539,7 +3539,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -3769,7 +3769,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -3915,7 +3915,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -3961,7 +3961,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -3980,7 +3980,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -3999,7 +3999,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4019,7 +4019,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4038,7 +4038,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4072,7 +4072,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4091,7 +4091,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4110,7 +4110,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4144,7 +4144,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4180,7 +4180,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4199,7 +4199,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4220,7 +4220,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4239,7 +4239,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4255,7 +4255,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4268,7 +4268,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4287,7 +4287,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4306,7 +4306,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4325,7 +4325,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4345,7 +4345,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4377,7 +4377,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4396,7 +4396,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4415,7 +4415,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4434,7 +4434,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4453,7 +4453,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4474,7 +4474,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4493,7 +4493,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4509,7 +4509,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -4522,7 +4522,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4541,7 +4541,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4560,7 +4560,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4743,7 +4743,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4867,7 +4867,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5097,7 +5097,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -5243,7 +5243,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5289,7 +5289,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5308,7 +5308,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5327,7 +5327,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5347,7 +5347,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5366,7 +5366,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5400,7 +5400,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5419,7 +5419,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5438,7 +5438,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5472,7 +5472,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5508,7 +5508,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5527,7 +5527,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5548,7 +5548,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5567,7 +5567,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5583,7 +5583,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -5596,7 +5596,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5615,7 +5615,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5634,7 +5634,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5653,7 +5653,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5685,7 +5685,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5704,7 +5704,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5723,7 +5723,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5742,7 +5742,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5761,7 +5761,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5782,7 +5782,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5801,7 +5801,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5817,7 +5817,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5830,7 +5830,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5849,7 +5849,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5868,7 +5868,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5995,7 +5995,7 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6055,7 +6055,7 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -6144,7 +6144,7 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -6168,7 +6168,7 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -6228,7 +6228,7 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6301,7 +6301,7 @@
     "singleFixed64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 18446744073709552000,
+          "exclusiveMaximum": 18446744073709551616,
           "minimum": 0,
           "type": "integer"
         },
@@ -6346,7 +6346,7 @@
     "singleInt64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854776000,
+          "exclusiveMaximum": 9223372036854775808,
           "minimum": -9223372036854775808,
           "type": "integer"
         },
@@ -6388,7 +6388,7 @@
     "singleSfixed64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854776000,
+          "exclusiveMaximum": 9223372036854775808,
           "minimum": -9223372036854775808,
           "type": "integer"
         },
@@ -6406,7 +6406,7 @@
     "singleSint64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854776000,
+          "exclusiveMaximum": 9223372036854775808,
           "minimum": -9223372036854775808,
           "type": "integer"
         },
@@ -6439,7 +6439,7 @@
     "singleUint64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 18446744073709552000,
+          "exclusiveMaximum": 18446744073709551616,
           "minimum": 0,
           "type": "integer"
         },

--- a/internal/testdata/jsonschema/bufext.cel.expr.conformance.proto3.TestAllTypes.schema.json
+++ b/internal/testdata/jsonschema/bufext.cel.expr.conformance.proto3.TestAllTypes.schema.json
@@ -178,7 +178,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -302,7 +302,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -532,7 +532,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -678,7 +678,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -724,7 +724,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -743,7 +743,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -762,7 +762,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -782,7 +782,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -801,7 +801,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -835,7 +835,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -854,7 +854,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -873,7 +873,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -907,7 +907,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -943,7 +943,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -962,7 +962,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -983,7 +983,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -1002,7 +1002,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -1018,7 +1018,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -1031,7 +1031,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -1050,7 +1050,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -1069,7 +1069,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -1088,7 +1088,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -1108,7 +1108,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -1140,7 +1140,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -1159,7 +1159,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -1178,7 +1178,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -1197,7 +1197,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -1216,7 +1216,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -1237,7 +1237,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -1256,7 +1256,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -1272,7 +1272,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -1285,7 +1285,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -1304,7 +1304,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -1323,7 +1323,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -1506,7 +1506,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -1630,7 +1630,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -1860,7 +1860,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -2006,7 +2006,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2052,7 +2052,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2071,7 +2071,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2090,7 +2090,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2110,7 +2110,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2129,7 +2129,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2163,7 +2163,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2182,7 +2182,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2201,7 +2201,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2235,7 +2235,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2271,7 +2271,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2290,7 +2290,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2311,7 +2311,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2330,7 +2330,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2346,7 +2346,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -2359,7 +2359,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2378,7 +2378,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2397,7 +2397,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2416,7 +2416,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2448,7 +2448,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2467,7 +2467,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2486,7 +2486,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2505,7 +2505,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2524,7 +2524,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2545,7 +2545,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2564,7 +2564,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2580,7 +2580,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2593,7 +2593,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2612,7 +2612,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2631,7 +2631,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2758,7 +2758,7 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2818,7 +2818,7 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -2907,7 +2907,7 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -2931,7 +2931,7 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -2991,7 +2991,7 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -3064,7 +3064,7 @@
     "^(singleFixed64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 18446744073709552000,
+          "exclusiveMaximum": 18446744073709551616,
           "minimum": 0,
           "type": "integer"
         },
@@ -3109,7 +3109,7 @@
     "^(singleInt64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854776000,
+          "exclusiveMaximum": 9223372036854775808,
           "minimum": -9223372036854775808,
           "type": "integer"
         },
@@ -3151,7 +3151,7 @@
     "^(singleSfixed64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854776000,
+          "exclusiveMaximum": 9223372036854775808,
           "minimum": -9223372036854775808,
           "type": "integer"
         },
@@ -3169,7 +3169,7 @@
     "^(singleSint64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854776000,
+          "exclusiveMaximum": 9223372036854775808,
           "minimum": -9223372036854775808,
           "type": "integer"
         },
@@ -3202,7 +3202,7 @@
     "^(singleUint64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 18446744073709552000,
+          "exclusiveMaximum": 18446744073709551616,
           "minimum": 0,
           "type": "integer"
         },
@@ -3415,7 +3415,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -3539,7 +3539,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -3769,7 +3769,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -3915,7 +3915,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -3961,7 +3961,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -3980,7 +3980,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -3999,7 +3999,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4019,7 +4019,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4038,7 +4038,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4072,7 +4072,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4091,7 +4091,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4110,7 +4110,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4144,7 +4144,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4180,7 +4180,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4199,7 +4199,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4220,7 +4220,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4239,7 +4239,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4255,7 +4255,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4268,7 +4268,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4287,7 +4287,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4306,7 +4306,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4325,7 +4325,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4345,7 +4345,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4377,7 +4377,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4396,7 +4396,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4415,7 +4415,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4434,7 +4434,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4453,7 +4453,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4474,7 +4474,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4493,7 +4493,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4509,7 +4509,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -4522,7 +4522,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4541,7 +4541,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4560,7 +4560,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4743,7 +4743,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -4867,7 +4867,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5097,7 +5097,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -5243,7 +5243,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5289,7 +5289,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5308,7 +5308,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5327,7 +5327,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5347,7 +5347,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5366,7 +5366,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5400,7 +5400,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5419,7 +5419,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5438,7 +5438,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5472,7 +5472,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5508,7 +5508,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5527,7 +5527,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5548,7 +5548,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5567,7 +5567,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5583,7 +5583,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -5596,7 +5596,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5615,7 +5615,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5634,7 +5634,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5653,7 +5653,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5685,7 +5685,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5704,7 +5704,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5723,7 +5723,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5742,7 +5742,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5761,7 +5761,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5782,7 +5782,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5801,7 +5801,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5817,7 +5817,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5830,7 +5830,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5849,7 +5849,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5868,7 +5868,7 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5995,7 +5995,7 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6055,7 +6055,7 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -6144,7 +6144,7 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -6168,7 +6168,7 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854776000,
+            "exclusiveMaximum": 9223372036854775808,
             "minimum": -9223372036854775808,
             "type": "integer"
           },
@@ -6228,7 +6228,7 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709552000,
+            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6301,7 +6301,7 @@
     "single_fixed64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 18446744073709552000,
+          "exclusiveMaximum": 18446744073709551616,
           "minimum": 0,
           "type": "integer"
         },
@@ -6346,7 +6346,7 @@
     "single_int64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854776000,
+          "exclusiveMaximum": 9223372036854775808,
           "minimum": -9223372036854775808,
           "type": "integer"
         },
@@ -6388,7 +6388,7 @@
     "single_sfixed64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854776000,
+          "exclusiveMaximum": 9223372036854775808,
           "minimum": -9223372036854775808,
           "type": "integer"
         },
@@ -6406,7 +6406,7 @@
     "single_sint64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854776000,
+          "exclusiveMaximum": 9223372036854775808,
           "minimum": -9223372036854775808,
           "type": "integer"
         },
@@ -6439,7 +6439,7 @@
     "single_uint64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 18446744073709552000,
+          "exclusiveMaximum": 18446744073709551616,
           "minimum": 0,
           "type": "integer"
         },

--- a/internal/testdata/jsonschema/google.protobuf.Int64Value.jsonschema.json
+++ b/internal/testdata/jsonschema/google.protobuf.Int64Value.jsonschema.json
@@ -3,7 +3,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "anyOf": [
     {
-      "exclusiveMaximum": 9223372036854776000,
+      "exclusiveMaximum": 9223372036854775808,
       "minimum": -9223372036854775808,
       "type": "integer"
     },

--- a/internal/testdata/jsonschema/google.protobuf.Int64Value.schema.json
+++ b/internal/testdata/jsonschema/google.protobuf.Int64Value.schema.json
@@ -3,7 +3,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "anyOf": [
     {
-      "exclusiveMaximum": 9223372036854776000,
+      "exclusiveMaximum": 9223372036854775808,
       "minimum": -9223372036854775808,
       "type": "integer"
     },

--- a/internal/testdata/jsonschema/google.protobuf.UInt64Value.jsonschema.json
+++ b/internal/testdata/jsonschema/google.protobuf.UInt64Value.jsonschema.json
@@ -3,7 +3,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "anyOf": [
     {
-      "exclusiveMaximum": 18446744073709552000,
+      "exclusiveMaximum": 18446744073709551616,
       "minimum": 0,
       "type": "integer"
     },

--- a/internal/testdata/jsonschema/google.protobuf.UInt64Value.schema.json
+++ b/internal/testdata/jsonschema/google.protobuf.UInt64Value.schema.json
@@ -3,7 +3,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "anyOf": [
     {
-      "exclusiveMaximum": 18446744073709552000,
+      "exclusiveMaximum": 18446744073709551616,
       "minimum": 0,
       "type": "integer"
     },


### PR DESCRIPTION
Update the exclusive maximum values for int64 and uint64 types to the correct values.

Fixes #60.