### PR TITLE
Add an option to enable 'additionalProperties'

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ message Product {
 
 Results in the following JSON Schema files:
 
-*  `*.schema.json` files are generated with underscore-case fields
-*  `*.jsonschema.json` files are generated with camelCase
+- `*.schema.json` files are generated with underscore-case fields
+- `*.jsonschema.json` files are generated with camelCase
 
 <details>
 <summary>Product.schema.json</summary>
@@ -164,6 +164,13 @@ Results in the following JSON Schema files:
 ```
 
 </details>
+
+### Options
+
+The JSON Schema plugin supports the following options:
+
+- `additional_properties` - If specified, the generated schema will allow additional properties. Used to
+  allow the sender of a message to have a newer version of the schema than the receiver.
 
 ## Community
 

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -11,3 +11,7 @@ plugins:
   - remote: buf.build/protocolbuffers/go:v1.36.6
     out: internal/gen/proto
     opt: paths=source_relative
+  - local: ["go", "run", "./cmd/protoc-gen-jsonschema"]
+    out: internal/gen/jsonschema
+    opt:
+     - additional_properties

--- a/internal/gen/jsonschema/buf.protoschema.test.v1.ConstraintTest.RequiredImplicit.jsonschema.json
+++ b/internal/gen/jsonschema/buf.protoschema.test.v1.ConstraintTest.RequiredImplicit.jsonschema.json
@@ -1,0 +1,33 @@
+{
+  "$id": "buf.protoschema.test.v1.ConstraintTest.RequiredImplicit.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "patternProperties": {
+    "^(bool_value)$": {
+      "enum": [
+        true
+      ],
+      "type": "boolean"
+    },
+    "^(string_value)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "boolValue": {
+      "enum": [
+        true
+      ],
+      "type": "boolean"
+    },
+    "stringValue": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "bool_value",
+    "string_value"
+  ],
+  "title": "Required Implicit",
+  "type": "object"
+}

--- a/internal/gen/jsonschema/buf.protoschema.test.v1.ConstraintTest.RequiredImplicit.schema.json
+++ b/internal/gen/jsonschema/buf.protoschema.test.v1.ConstraintTest.RequiredImplicit.schema.json
@@ -1,0 +1,33 @@
+{
+  "$id": "buf.protoschema.test.v1.ConstraintTest.RequiredImplicit.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "patternProperties": {
+    "^(boolValue)$": {
+      "enum": [
+        true
+      ],
+      "type": "boolean"
+    },
+    "^(stringValue)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "bool_value": {
+      "enum": [
+        true
+      ],
+      "type": "boolean"
+    },
+    "string_value": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "bool_value",
+    "string_value"
+  ],
+  "title": "Required Implicit",
+  "type": "object"
+}

--- a/internal/gen/jsonschema/buf.protoschema.test.v1.ConstraintTest.RequiredOptional.jsonschema.json
+++ b/internal/gen/jsonschema/buf.protoschema.test.v1.ConstraintTest.RequiredOptional.jsonschema.json
@@ -1,0 +1,27 @@
+{
+  "$id": "buf.protoschema.test.v1.ConstraintTest.RequiredOptional.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "patternProperties": {
+    "^(bool_value)$": {
+      "type": "boolean"
+    },
+    "^(string_value)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "boolValue": {
+      "type": "boolean"
+    },
+    "stringValue": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "bool_value",
+    "string_value"
+  ],
+  "title": "Required Optional",
+  "type": "object"
+}

--- a/internal/gen/jsonschema/buf.protoschema.test.v1.ConstraintTest.RequiredOptional.schema.json
+++ b/internal/gen/jsonschema/buf.protoschema.test.v1.ConstraintTest.RequiredOptional.schema.json
@@ -1,0 +1,27 @@
+{
+  "$id": "buf.protoschema.test.v1.ConstraintTest.RequiredOptional.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "patternProperties": {
+    "^(boolValue)$": {
+      "type": "boolean"
+    },
+    "^(stringValue)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "bool_value": {
+      "type": "boolean"
+    },
+    "string_value": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "bool_value",
+    "string_value"
+  ],
+  "title": "Required Optional",
+  "type": "object"
+}

--- a/internal/gen/jsonschema/buf.protoschema.test.v1.ConstraintTest.jsonschema.json
+++ b/internal/gen/jsonschema/buf.protoschema.test.v1.ConstraintTest.jsonschema.json
@@ -1,0 +1,2483 @@
+{
+  "$id": "buf.protoschema.test.v1.ConstraintTest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "patternProperties": {
+    "^(address_string)$": {
+      "pattern": "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$|^(([0-9a-fA-F]{1,4}::?){1,7}([0-9a-fA-F]{1,4})|([0-9a-fA-F]{1,4}:){1,7}:|:((([0-9a-fA-F]{1,4}:){1,6})?[0-9a-fA-F]{1,4})?|::)$|^[A-Za-z0-9][A-Za-z0-9-]{0,63}(\\.[A-Za-z0-9-][A-Za-z0-9-]{0,63})*$",
+      "type": "string"
+    },
+    "^(const_bool)$": {
+      "enum": [
+        false
+      ],
+      "type": "boolean"
+    },
+    "^(const_double)$": {
+      "anyOf": [
+        {
+          "enum": [
+            5
+          ],
+          "type": "number"
+        },
+        {
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(const_enum)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "ENUM_VAL2"
+          ],
+          "title": "Enum",
+          "type": "string"
+        },
+        {
+          "enum": [
+            2
+          ],
+          "type": "integer"
+        }
+      ]
+    },
+    "^(const_fixed32)$": {
+      "enum": [
+        5
+      ],
+      "exclusiveMaximum": 4294967296,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "^(const_fixed64)$": {
+      "anyOf": [
+        {
+          "enum": [
+            5
+          ],
+          "exclusiveMaximum": 18446744073709552000,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(const_float)$": {
+      "anyOf": [
+        {
+          "enum": [
+            5
+          ],
+          "maximum": 3.4028234663852886e+38,
+          "minimum": -3.4028234663852886e+38,
+          "type": "number"
+        },
+        {
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(const_int32)$": {
+      "enum": [
+        5
+      ],
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(const_int64)$": {
+      "anyOf": [
+        {
+          "enum": [
+            5
+          ],
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(const_sfixed32)$": {
+      "enum": [
+        5
+      ],
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(const_sfixed64)$": {
+      "anyOf": [
+        {
+          "enum": [
+            5
+          ],
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(const_sint32)$": {
+      "enum": [
+        5
+      ],
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(const_sint64)$": {
+      "anyOf": [
+        {
+          "enum": [
+            5
+          ],
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(const_string)$": {
+      "enum": [
+        "const"
+      ],
+      "type": "string"
+    },
+    "^(const_uint32)$": {
+      "enum": [
+        5
+      ],
+      "exclusiveMaximum": 4294967296,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "^(const_uint64)$": {
+      "anyOf": [
+        {
+          "enum": [
+            5
+          ],
+          "exclusiveMaximum": 18446744073709552000,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(contains_string)$": {
+      "pattern": ".*_contains_.*",
+      "type": "string"
+    },
+    "^(defined_only_enum)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "ENUM_UNSPECIFIED",
+            "ENUM_VAL1",
+            "ENUM_VAL2",
+            "ENUM_VAL7"
+          ],
+          "title": "Enum",
+          "type": "string"
+        },
+        {
+          "enum": [
+            0,
+            1,
+            2,
+            7
+          ],
+          "type": "integer"
+        }
+      ]
+    },
+    "^(defined_only_not_in_enum)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "ENUM_VAL1",
+            "ENUM_VAL2",
+            "ENUM_VAL7"
+          ],
+          "title": "Enum",
+          "type": "string"
+        },
+        {
+          "enum": [
+            1,
+            2,
+            7
+          ],
+          "type": "integer"
+        }
+      ]
+    },
+    "^(email_string)$": {
+      "format": "email",
+      "type": "string"
+    },
+    "^(finite_double)$": {
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(finite_float)$": {
+      "anyOf": [
+        {
+          "maximum": 3.4028234663852886e+38,
+          "minimum": -3.4028234663852886e+38,
+          "type": "number"
+        },
+        {
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(gt_double)$": {
+      "anyOf": [
+        {
+          "exclusiveMinimum": 5,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "^(gt_fixed32)$": {
+      "exclusiveMaximum": 4294967296,
+      "exclusiveMinimum": 5,
+      "type": "integer"
+    },
+    "^(gt_fixed64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 18446744073709552000,
+          "exclusiveMinimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(gt_float)$": {
+      "anyOf": [
+        {
+          "exclusiveMinimum": 5,
+          "maximum": 3.4028234663852886e+38,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "^(gt_int32)$": {
+      "exclusiveMaximum": 2147483648,
+      "exclusiveMinimum": 5,
+      "type": "integer"
+    },
+    "^(gt_int64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "exclusiveMinimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(gt_sfixed32)$": {
+      "exclusiveMaximum": 2147483648,
+      "exclusiveMinimum": 5,
+      "type": "integer"
+    },
+    "^(gt_sfixed64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "exclusiveMinimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(gt_sint32)$": {
+      "exclusiveMaximum": 2147483648,
+      "exclusiveMinimum": 5,
+      "type": "integer"
+    },
+    "^(gt_sint64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "exclusiveMinimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(gt_uint32)$": {
+      "exclusiveMaximum": 4294967296,
+      "exclusiveMinimum": 5,
+      "type": "integer"
+    },
+    "^(gt_uint64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 18446744073709552000,
+          "exclusiveMinimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(gte_double)$": {
+      "anyOf": [
+        {
+          "minimum": 5,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "^(gte_fixed32)$": {
+      "exclusiveMaximum": 4294967296,
+      "minimum": 5,
+      "type": "integer"
+    },
+    "^(gte_fixed64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 18446744073709552000,
+          "minimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(gte_float)$": {
+      "anyOf": [
+        {
+          "maximum": 3.4028234663852886e+38,
+          "minimum": 5,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "^(gte_int32)$": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": 5,
+      "type": "integer"
+    },
+    "^(gte_int64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(gte_sfixed32)$": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": 5,
+      "type": "integer"
+    },
+    "^(gte_sfixed64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(gte_sint32)$": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": 5,
+      "type": "integer"
+    },
+    "^(gte_sint64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(gte_uint32)$": {
+      "exclusiveMaximum": 4294967296,
+      "minimum": 5,
+      "type": "integer"
+    },
+    "^(gte_uint64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 18446744073709552000,
+          "minimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(host_and_port_string)$": {
+      "pattern": "^([A-Za-z0-9][A-Za-z0-9-]{0,63}(\\.[A-Za-z0-9-][A-Za-z0-9-]{0,63})*|((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)|\\[(([0-9a-fA-F]{1,4}::?){1,7}([0-9a-fA-F]{1,4})|([0-9a-fA-F]{1,4}:){1,7}:|:((([0-9a-fA-F]{1,4}:){1,6})?[0-9a-fA-F]{1,4})?|::)\\]):([1-9][0-9]{0,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$",
+      "type": "string"
+    },
+    "^(hostname_string)$": {
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9-]{0,63}(\\.[A-Za-z0-9-][A-Za-z0-9-]{0,63})*$",
+      "type": "string"
+    },
+    "^(http_header_name_strict_string)$": {
+      "pattern": "^:?[0-9a-zA-Z!#$%\u0026\\'*+-.^_|~\\x60]+$",
+      "type": "string"
+    },
+    "^(in_and_not_in_enum)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "ENUM_VAL1"
+          ],
+          "title": "Enum",
+          "type": "string"
+        },
+        {
+          "enum": [
+            1
+          ],
+          "type": "integer"
+        }
+      ]
+    },
+    "^(in_double)$": {
+      "anyOf": [
+        {
+          "enum": [
+            1,
+            2
+          ],
+          "type": "number"
+        },
+        {
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(in_enum)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "ENUM_VAL1",
+            "ENUM_VAL2"
+          ],
+          "title": "Enum",
+          "type": "string"
+        },
+        {
+          "enum": [
+            1,
+            2
+          ],
+          "type": "integer"
+        }
+      ]
+    },
+    "^(in_fixed32)$": {
+      "enum": [
+        1,
+        2
+      ],
+      "exclusiveMaximum": 4294967296,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "^(in_fixed64)$": {
+      "anyOf": [
+        {
+          "enum": [
+            1,
+            2
+          ],
+          "exclusiveMaximum": 18446744073709552000,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(in_float)$": {
+      "anyOf": [
+        {
+          "enum": [
+            1,
+            2
+          ],
+          "maximum": 3.4028234663852886e+38,
+          "minimum": -3.4028234663852886e+38,
+          "type": "number"
+        },
+        {
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(in_int32)$": {
+      "enum": [
+        1,
+        2
+      ],
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(in_int64)$": {
+      "anyOf": [
+        {
+          "enum": [
+            1,
+            2
+          ],
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(in_map)$": {
+      "additionalProperties": {
+        "enum": [
+          "value1",
+          "value2"
+        ],
+        "type": "string"
+      },
+      "propertyNames": {
+        "enum": [
+          "key1",
+          "key2"
+        ],
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(in_sfixed32)$": {
+      "enum": [
+        1,
+        2
+      ],
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(in_sfixed64)$": {
+      "anyOf": [
+        {
+          "enum": [
+            1,
+            2
+          ],
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(in_sint32)$": {
+      "enum": [
+        1,
+        2
+      ],
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(in_sint64)$": {
+      "anyOf": [
+        {
+          "enum": [
+            1,
+            2
+          ],
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(in_string)$": {
+      "enum": [
+        "in1",
+        "in2"
+      ],
+      "type": "string"
+    },
+    "^(in_uint32)$": {
+      "enum": [
+        1,
+        2
+      ],
+      "exclusiveMaximum": 4294967296,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "^(in_uint64)$": {
+      "anyOf": [
+        {
+          "enum": [
+            1,
+            2
+          ],
+          "exclusiveMaximum": 18446744073709552000,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(ip_prefix_string)$": {
+      "pattern": "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}0/([0-9]|[12][0-9]|3[0-2])$|^(([0-9a-fA-F]{1,4}:){1,7}:|::)/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$",
+      "type": "string"
+    },
+    "^(ip_string)$": {
+      "pattern": "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$|^(([0-9a-fA-F]{1,4}::?){1,7}([0-9a-fA-F]{1,4})|([0-9a-fA-F]{1,4}:){1,7}:|:((([0-9a-fA-F]{1,4}:){1,6})?[0-9a-fA-F]{1,4})?|::)$",
+      "type": "string"
+    },
+    "^(ip_with_prefixlen_string)$": {
+      "pattern": "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/([0-9]|[12][0-9]|3[0-2])$|^(([0-9a-fA-F]{1,4}::?){1,7}([0-9a-fA-F]{1,4})|([0-9a-fA-F]{1,4}:){1,7}:|:((([0-9a-fA-F]{1,4}:){1,6})?[0-9a-fA-F]{1,4})?|::)/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$",
+      "type": "string"
+    },
+    "^(ipv4_prefix_string)$": {
+      "pattern": "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}0/([0-9]|[12][0-9]|3[0-2])$",
+      "type": "string"
+    },
+    "^(ipv4_string)$": {
+      "format": "ipv4",
+      "type": "string"
+    },
+    "^(ipv4_with_prefixlen_string)$": {
+      "pattern": "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/([0-9]|[12][0-9]|3[0-2])$",
+      "type": "string"
+    },
+    "^(ipv6_prefix_string)$": {
+      "pattern": "^(([0-9a-fA-F]{1,4}:){1,7}:|::)/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$",
+      "type": "string"
+    },
+    "^(ipv6_string)$": {
+      "format": "ipv6",
+      "type": "string"
+    },
+    "^(ipv6_with_prefixlen_string)$": {
+      "pattern": "^(([0-9a-fA-F]{1,4}::?){1,7}([0-9a-fA-F]{1,4})|([0-9a-fA-F]{1,4}:){1,7}:|:((([0-9a-fA-F]{1,4}:){1,6})?[0-9a-fA-F]{1,4})?|::)/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$",
+      "type": "string"
+    },
+    "^(len_bytes)$": {
+      "maxLength": 8,
+      "minLength": 7,
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "^(len_string)$": {
+      "maxLength": 5,
+      "minLength": 5,
+      "type": "string"
+    },
+    "^(lt_double)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 5,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "-Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "^(lt_fixed32)$": {
+      "exclusiveMaximum": 5,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "^(lt_fixed64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 5,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(lt_float)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 5,
+          "minimum": -3.4028234663852886e+38,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "-Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "^(lt_gt_double)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 1,
+          "type": "number"
+        },
+        {
+          "exclusiveMinimum": 5,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "Infinity",
+            "-Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "^(lt_gt_float)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 1,
+          "type": "number"
+        },
+        {
+          "exclusiveMinimum": 5,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "Infinity",
+            "-Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "^(lt_gt_int32)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 1,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        {
+          "exclusiveMaximum": 2147483648,
+          "exclusiveMinimum": 5,
+          "type": "integer"
+        }
+      ]
+    },
+    "^(lt_gt_int64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 1,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "exclusiveMinimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(lt_gt_uint32)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 1,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "exclusiveMaximum": 4294967296,
+          "exclusiveMinimum": 5,
+          "type": "integer"
+        }
+      ]
+    },
+    "^(lt_gt_uint64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 1,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        },
+        {
+          "exclusiveMaximum": 18446744073709552000,
+          "exclusiveMinimum": 5,
+          "type": "integer"
+        }
+      ]
+    },
+    "^(lt_int32)$": {
+      "exclusiveMaximum": 5,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(lt_int64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 5,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(lt_sfixed32)$": {
+      "exclusiveMaximum": 5,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(lt_sfixed64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 5,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(lt_sint32)$": {
+      "exclusiveMaximum": 5,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(lt_sint64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 5,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(lt_uint32)$": {
+      "exclusiveMaximum": 5,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "^(lt_uint64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 5,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(lte_double)$": {
+      "anyOf": [
+        {
+          "maximum": 5,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "-Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "^(lte_fixed32)$": {
+      "maximum": 5,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "^(lte_fixed64)$": {
+      "anyOf": [
+        {
+          "maximum": 5,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(lte_float)$": {
+      "anyOf": [
+        {
+          "maximum": 5,
+          "minimum": -3.4028234663852886e+38,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "-Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "^(lte_int32)$": {
+      "maximum": 5,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(lte_int64)$": {
+      "anyOf": [
+        {
+          "maximum": 5,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(lte_sfixed32)$": {
+      "maximum": 5,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(lte_sfixed64)$": {
+      "anyOf": [
+        {
+          "maximum": 5,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(lte_sint32)$": {
+      "maximum": 5,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(lte_sint64)$": {
+      "anyOf": [
+        {
+          "maximum": 5,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(lte_uint32)$": {
+      "maximum": 5,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "^(lte_uint64)$": {
+      "anyOf": [
+        {
+          "maximum": 5,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(max_len_bytes)$": {
+      "maxLength": 8,
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "^(max_len_string)$": {
+      "maxLength": 5,
+      "type": "string"
+    },
+    "^(min_len_bytes)$": {
+      "minLength": 7,
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "^(min_len_string)$": {
+      "minLength": 5,
+      "type": "string"
+    },
+    "^(min_max_len_bytes)$": {
+      "maxLength": 16,
+      "minLength": 7,
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "^(min_max_len_string)$": {
+      "maxLength": 10,
+      "minLength": 5,
+      "type": "string"
+    },
+    "^(not_in_enum)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "ENUM_VAL1",
+            "ENUM_VAL2"
+          ],
+          "title": "Enum",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "^(pattern_string)$": {
+      "pattern": "^pat*ern$",
+      "type": "string"
+    },
+    "^(prefix_contains_suffix_string)$": {
+      "pattern": "^prefix_.*contains.*_suffix$",
+      "type": "string"
+    },
+    "^(prefix_string)$": {
+      "pattern": "^prefix_.*",
+      "type": "string"
+    },
+    "^(prefix_suffix_string)$": {
+      "pattern": "^prefix_.*_suffix$",
+      "type": "string"
+    },
+    "^(required_implicit)$": {
+      "$ref": "buf.protoschema.test.v1.ConstraintTest.RequiredImplicit.jsonschema.json"
+    },
+    "^(required_optional)$": {
+      "$ref": "buf.protoschema.test.v1.ConstraintTest.RequiredOptional.jsonschema.json"
+    },
+    "^(suffix_string)$": {
+      "pattern": ".*_suffix$",
+      "type": "string"
+    },
+    "^(tuuid_string)$": {
+      "pattern": "^[0-9a-fA-F]{32}$",
+      "type": "string"
+    },
+    "^(uri_ref_string)$": {
+      "pattern": "^(?:(?:[a-zA-Z][a-zA-Z\\d+\\-.]*):)?(?:\\/\\/(?:[A-Za-z0-9\\-\\.]+(?::\\d+)?))?(/[^\\?#]*)?(?:\\?([^\\#]*))?(?:\\#(.*))?$",
+      "type": "string"
+    },
+    "^(uri_string)$": {
+      "pattern": "^(?:(?:[a-zA-Z][a-zA-Z\\d+\\-.]*):)?(?://(?:[A-Za-z0-9\\-\\.]+(?::\\d+)?))?(/[^\\?#]*)?(?:\\?([^\\#]*))?(?:\\#(.*))?$",
+      "type": "string"
+    },
+    "^(uuid_string)$": {
+      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+      "type": "string"
+    }
+  },
+  "properties": {
+    "addressString": {
+      "pattern": "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$|^(([0-9a-fA-F]{1,4}::?){1,7}([0-9a-fA-F]{1,4})|([0-9a-fA-F]{1,4}:){1,7}:|:((([0-9a-fA-F]{1,4}:){1,6})?[0-9a-fA-F]{1,4})?|::)$|^[A-Za-z0-9][A-Za-z0-9-]{0,63}(\\.[A-Za-z0-9-][A-Za-z0-9-]{0,63})*$",
+      "type": "string"
+    },
+    "constBool": {
+      "enum": [
+        false
+      ],
+      "type": "boolean"
+    },
+    "constDouble": {
+      "anyOf": [
+        {
+          "enum": [
+            5
+          ],
+          "type": "number"
+        },
+        {
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
+          "type": "string"
+        }
+      ]
+    },
+    "constEnum": {
+      "anyOf": [
+        {
+          "enum": [
+            "ENUM_VAL2"
+          ],
+          "title": "Enum",
+          "type": "string"
+        },
+        {
+          "enum": [
+            2
+          ],
+          "type": "integer"
+        }
+      ]
+    },
+    "constFixed32": {
+      "enum": [
+        5
+      ],
+      "exclusiveMaximum": 4294967296,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "constFixed64": {
+      "anyOf": [
+        {
+          "enum": [
+            5
+          ],
+          "exclusiveMaximum": 18446744073709552000,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "constFloat": {
+      "anyOf": [
+        {
+          "enum": [
+            5
+          ],
+          "maximum": 3.4028234663852886e+38,
+          "minimum": -3.4028234663852886e+38,
+          "type": "number"
+        },
+        {
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
+          "type": "string"
+        }
+      ]
+    },
+    "constInt32": {
+      "enum": [
+        5
+      ],
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "constInt64": {
+      "anyOf": [
+        {
+          "enum": [
+            5
+          ],
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "constSfixed32": {
+      "enum": [
+        5
+      ],
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "constSfixed64": {
+      "anyOf": [
+        {
+          "enum": [
+            5
+          ],
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "constSint32": {
+      "enum": [
+        5
+      ],
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "constSint64": {
+      "anyOf": [
+        {
+          "enum": [
+            5
+          ],
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "constString": {
+      "enum": [
+        "const"
+      ],
+      "type": "string"
+    },
+    "constUint32": {
+      "enum": [
+        5
+      ],
+      "exclusiveMaximum": 4294967296,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "constUint64": {
+      "anyOf": [
+        {
+          "enum": [
+            5
+          ],
+          "exclusiveMaximum": 18446744073709552000,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "containsString": {
+      "pattern": ".*_contains_.*",
+      "type": "string"
+    },
+    "definedOnlyEnum": {
+      "anyOf": [
+        {
+          "enum": [
+            "ENUM_UNSPECIFIED",
+            "ENUM_VAL1",
+            "ENUM_VAL2",
+            "ENUM_VAL7"
+          ],
+          "title": "Enum",
+          "type": "string"
+        },
+        {
+          "enum": [
+            0,
+            1,
+            2,
+            7
+          ],
+          "type": "integer"
+        }
+      ]
+    },
+    "definedOnlyNotInEnum": {
+      "anyOf": [
+        {
+          "enum": [
+            "ENUM_VAL1",
+            "ENUM_VAL2",
+            "ENUM_VAL7"
+          ],
+          "title": "Enum",
+          "type": "string"
+        },
+        {
+          "enum": [
+            1,
+            2,
+            7
+          ],
+          "type": "integer"
+        }
+      ]
+    },
+    "emailString": {
+      "format": "email",
+      "type": "string"
+    },
+    "finiteDouble": {
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
+          "type": "string"
+        }
+      ]
+    },
+    "finiteFloat": {
+      "anyOf": [
+        {
+          "maximum": 3.4028234663852886e+38,
+          "minimum": -3.4028234663852886e+38,
+          "type": "number"
+        },
+        {
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
+          "type": "string"
+        }
+      ]
+    },
+    "gtDouble": {
+      "anyOf": [
+        {
+          "exclusiveMinimum": 5,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "gtFixed32": {
+      "exclusiveMaximum": 4294967296,
+      "exclusiveMinimum": 5,
+      "type": "integer"
+    },
+    "gtFixed64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 18446744073709552000,
+          "exclusiveMinimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "gtFloat": {
+      "anyOf": [
+        {
+          "exclusiveMinimum": 5,
+          "maximum": 3.4028234663852886e+38,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "gtInt32": {
+      "exclusiveMaximum": 2147483648,
+      "exclusiveMinimum": 5,
+      "type": "integer"
+    },
+    "gtInt64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "exclusiveMinimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "gtSfixed32": {
+      "exclusiveMaximum": 2147483648,
+      "exclusiveMinimum": 5,
+      "type": "integer"
+    },
+    "gtSfixed64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "exclusiveMinimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "gtSint32": {
+      "exclusiveMaximum": 2147483648,
+      "exclusiveMinimum": 5,
+      "type": "integer"
+    },
+    "gtSint64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "exclusiveMinimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "gtUint32": {
+      "exclusiveMaximum": 4294967296,
+      "exclusiveMinimum": 5,
+      "type": "integer"
+    },
+    "gtUint64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 18446744073709552000,
+          "exclusiveMinimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "gteDouble": {
+      "anyOf": [
+        {
+          "minimum": 5,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "gteFixed32": {
+      "exclusiveMaximum": 4294967296,
+      "minimum": 5,
+      "type": "integer"
+    },
+    "gteFixed64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 18446744073709552000,
+          "minimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "gteFloat": {
+      "anyOf": [
+        {
+          "maximum": 3.4028234663852886e+38,
+          "minimum": 5,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "gteInt32": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": 5,
+      "type": "integer"
+    },
+    "gteInt64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "gteSfixed32": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": 5,
+      "type": "integer"
+    },
+    "gteSfixed64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "gteSint32": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": 5,
+      "type": "integer"
+    },
+    "gteSint64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "gteUint32": {
+      "exclusiveMaximum": 4294967296,
+      "minimum": 5,
+      "type": "integer"
+    },
+    "gteUint64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 18446744073709552000,
+          "minimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "hostAndPortString": {
+      "pattern": "^([A-Za-z0-9][A-Za-z0-9-]{0,63}(\\.[A-Za-z0-9-][A-Za-z0-9-]{0,63})*|((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)|\\[(([0-9a-fA-F]{1,4}::?){1,7}([0-9a-fA-F]{1,4})|([0-9a-fA-F]{1,4}:){1,7}:|:((([0-9a-fA-F]{1,4}:){1,6})?[0-9a-fA-F]{1,4})?|::)\\]):([1-9][0-9]{0,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$",
+      "type": "string"
+    },
+    "hostnameString": {
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9-]{0,63}(\\.[A-Za-z0-9-][A-Za-z0-9-]{0,63})*$",
+      "type": "string"
+    },
+    "httpHeaderNameStrictString": {
+      "pattern": "^:?[0-9a-zA-Z!#$%\u0026\\'*+-.^_|~\\x60]+$",
+      "type": "string"
+    },
+    "inAndNotInEnum": {
+      "anyOf": [
+        {
+          "enum": [
+            "ENUM_VAL1"
+          ],
+          "title": "Enum",
+          "type": "string"
+        },
+        {
+          "enum": [
+            1
+          ],
+          "type": "integer"
+        }
+      ]
+    },
+    "inDouble": {
+      "anyOf": [
+        {
+          "enum": [
+            1,
+            2
+          ],
+          "type": "number"
+        },
+        {
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
+          "type": "string"
+        }
+      ]
+    },
+    "inEnum": {
+      "anyOf": [
+        {
+          "enum": [
+            "ENUM_VAL1",
+            "ENUM_VAL2"
+          ],
+          "title": "Enum",
+          "type": "string"
+        },
+        {
+          "enum": [
+            1,
+            2
+          ],
+          "type": "integer"
+        }
+      ]
+    },
+    "inFixed32": {
+      "enum": [
+        1,
+        2
+      ],
+      "exclusiveMaximum": 4294967296,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "inFixed64": {
+      "anyOf": [
+        {
+          "enum": [
+            1,
+            2
+          ],
+          "exclusiveMaximum": 18446744073709552000,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "inFloat": {
+      "anyOf": [
+        {
+          "enum": [
+            1,
+            2
+          ],
+          "maximum": 3.4028234663852886e+38,
+          "minimum": -3.4028234663852886e+38,
+          "type": "number"
+        },
+        {
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
+          "type": "string"
+        }
+      ]
+    },
+    "inInt32": {
+      "enum": [
+        1,
+        2
+      ],
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "inInt64": {
+      "anyOf": [
+        {
+          "enum": [
+            1,
+            2
+          ],
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "inMap": {
+      "additionalProperties": {
+        "enum": [
+          "value1",
+          "value2"
+        ],
+        "type": "string"
+      },
+      "propertyNames": {
+        "enum": [
+          "key1",
+          "key2"
+        ],
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "inSfixed32": {
+      "enum": [
+        1,
+        2
+      ],
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "inSfixed64": {
+      "anyOf": [
+        {
+          "enum": [
+            1,
+            2
+          ],
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "inSint32": {
+      "enum": [
+        1,
+        2
+      ],
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "inSint64": {
+      "anyOf": [
+        {
+          "enum": [
+            1,
+            2
+          ],
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "inString": {
+      "enum": [
+        "in1",
+        "in2"
+      ],
+      "type": "string"
+    },
+    "inUint32": {
+      "enum": [
+        1,
+        2
+      ],
+      "exclusiveMaximum": 4294967296,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "inUint64": {
+      "anyOf": [
+        {
+          "enum": [
+            1,
+            2
+          ],
+          "exclusiveMaximum": 18446744073709552000,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "ipPrefixString": {
+      "pattern": "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}0/([0-9]|[12][0-9]|3[0-2])$|^(([0-9a-fA-F]{1,4}:){1,7}:|::)/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$",
+      "type": "string"
+    },
+    "ipString": {
+      "pattern": "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$|^(([0-9a-fA-F]{1,4}::?){1,7}([0-9a-fA-F]{1,4})|([0-9a-fA-F]{1,4}:){1,7}:|:((([0-9a-fA-F]{1,4}:){1,6})?[0-9a-fA-F]{1,4})?|::)$",
+      "type": "string"
+    },
+    "ipWithPrefixlenString": {
+      "pattern": "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/([0-9]|[12][0-9]|3[0-2])$|^(([0-9a-fA-F]{1,4}::?){1,7}([0-9a-fA-F]{1,4})|([0-9a-fA-F]{1,4}:){1,7}:|:((([0-9a-fA-F]{1,4}:){1,6})?[0-9a-fA-F]{1,4})?|::)/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$",
+      "type": "string"
+    },
+    "ipv4PrefixString": {
+      "pattern": "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}0/([0-9]|[12][0-9]|3[0-2])$",
+      "type": "string"
+    },
+    "ipv4String": {
+      "format": "ipv4",
+      "type": "string"
+    },
+    "ipv4WithPrefixlenString": {
+      "pattern": "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/([0-9]|[12][0-9]|3[0-2])$",
+      "type": "string"
+    },
+    "ipv6PrefixString": {
+      "pattern": "^(([0-9a-fA-F]{1,4}:){1,7}:|::)/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$",
+      "type": "string"
+    },
+    "ipv6String": {
+      "format": "ipv6",
+      "type": "string"
+    },
+    "ipv6WithPrefixlenString": {
+      "pattern": "^(([0-9a-fA-F]{1,4}::?){1,7}([0-9a-fA-F]{1,4})|([0-9a-fA-F]{1,4}:){1,7}:|:((([0-9a-fA-F]{1,4}:){1,6})?[0-9a-fA-F]{1,4})?|::)/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$",
+      "type": "string"
+    },
+    "lenBytes": {
+      "maxLength": 8,
+      "minLength": 7,
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "lenString": {
+      "maxLength": 5,
+      "minLength": 5,
+      "type": "string"
+    },
+    "ltDouble": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 5,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "-Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "ltFixed32": {
+      "exclusiveMaximum": 5,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "ltFixed64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 5,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "ltFloat": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 5,
+          "minimum": -3.4028234663852886e+38,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "-Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "ltGtDouble": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 1,
+          "type": "number"
+        },
+        {
+          "exclusiveMinimum": 5,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "Infinity",
+            "-Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "ltGtFloat": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 1,
+          "type": "number"
+        },
+        {
+          "exclusiveMinimum": 5,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "Infinity",
+            "-Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "ltGtInt32": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 1,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        {
+          "exclusiveMaximum": 2147483648,
+          "exclusiveMinimum": 5,
+          "type": "integer"
+        }
+      ]
+    },
+    "ltGtInt64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 1,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "exclusiveMinimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "ltGtUint32": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 1,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "exclusiveMaximum": 4294967296,
+          "exclusiveMinimum": 5,
+          "type": "integer"
+        }
+      ]
+    },
+    "ltGtUint64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 1,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        },
+        {
+          "exclusiveMaximum": 18446744073709552000,
+          "exclusiveMinimum": 5,
+          "type": "integer"
+        }
+      ]
+    },
+    "ltInt32": {
+      "exclusiveMaximum": 5,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "ltInt64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 5,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "ltSfixed32": {
+      "exclusiveMaximum": 5,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "ltSfixed64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 5,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "ltSint32": {
+      "exclusiveMaximum": 5,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "ltSint64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 5,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "ltUint32": {
+      "exclusiveMaximum": 5,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "ltUint64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 5,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "lteDouble": {
+      "anyOf": [
+        {
+          "maximum": 5,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "-Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "lteFixed32": {
+      "maximum": 5,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "lteFixed64": {
+      "anyOf": [
+        {
+          "maximum": 5,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "lteFloat": {
+      "anyOf": [
+        {
+          "maximum": 5,
+          "minimum": -3.4028234663852886e+38,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "-Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "lteInt32": {
+      "maximum": 5,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "lteInt64": {
+      "anyOf": [
+        {
+          "maximum": 5,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "lteSfixed32": {
+      "maximum": 5,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "lteSfixed64": {
+      "anyOf": [
+        {
+          "maximum": 5,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "lteSint32": {
+      "maximum": 5,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "lteSint64": {
+      "anyOf": [
+        {
+          "maximum": 5,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "lteUint32": {
+      "maximum": 5,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "lteUint64": {
+      "anyOf": [
+        {
+          "maximum": 5,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "maxLenBytes": {
+      "maxLength": 8,
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "maxLenString": {
+      "maxLength": 5,
+      "type": "string"
+    },
+    "minLenBytes": {
+      "minLength": 7,
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "minLenString": {
+      "minLength": 5,
+      "type": "string"
+    },
+    "minMaxLenBytes": {
+      "maxLength": 16,
+      "minLength": 7,
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "minMaxLenString": {
+      "maxLength": 10,
+      "minLength": 5,
+      "type": "string"
+    },
+    "notInEnum": {
+      "anyOf": [
+        {
+          "enum": [
+            "ENUM_VAL1",
+            "ENUM_VAL2"
+          ],
+          "title": "Enum",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "patternString": {
+      "pattern": "^pat*ern$",
+      "type": "string"
+    },
+    "prefixContainsSuffixString": {
+      "pattern": "^prefix_.*contains.*_suffix$",
+      "type": "string"
+    },
+    "prefixString": {
+      "pattern": "^prefix_.*",
+      "type": "string"
+    },
+    "prefixSuffixString": {
+      "pattern": "^prefix_.*_suffix$",
+      "type": "string"
+    },
+    "requiredImplicit": {
+      "$ref": "buf.protoschema.test.v1.ConstraintTest.RequiredImplicit.jsonschema.json"
+    },
+    "requiredOptional": {
+      "$ref": "buf.protoschema.test.v1.ConstraintTest.RequiredOptional.jsonschema.json"
+    },
+    "suffixString": {
+      "pattern": ".*_suffix$",
+      "type": "string"
+    },
+    "tuuidString": {
+      "pattern": "^[0-9a-fA-F]{32}$",
+      "type": "string"
+    },
+    "uriRefString": {
+      "pattern": "^(?:(?:[a-zA-Z][a-zA-Z\\d+\\-.]*):)?(?:\\/\\/(?:[A-Za-z0-9\\-\\.]+(?::\\d+)?))?(/[^\\?#]*)?(?:\\?([^\\#]*))?(?:\\#(.*))?$",
+      "type": "string"
+    },
+    "uriString": {
+      "pattern": "^(?:(?:[a-zA-Z][a-zA-Z\\d+\\-.]*):)?(?://(?:[A-Za-z0-9\\-\\.]+(?::\\d+)?))?(/[^\\?#]*)?(?:\\?([^\\#]*))?(?:\\#(.*))?$",
+      "type": "string"
+    },
+    "uuidString": {
+      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+      "type": "string"
+    }
+  },
+  "title": "Constraint Test",
+  "type": "object"
+}

--- a/internal/gen/jsonschema/buf.protoschema.test.v1.ConstraintTest.schema.json
+++ b/internal/gen/jsonschema/buf.protoschema.test.v1.ConstraintTest.schema.json
@@ -1,0 +1,2483 @@
+{
+  "$id": "buf.protoschema.test.v1.ConstraintTest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "patternProperties": {
+    "^(addressString)$": {
+      "pattern": "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$|^(([0-9a-fA-F]{1,4}::?){1,7}([0-9a-fA-F]{1,4})|([0-9a-fA-F]{1,4}:){1,7}:|:((([0-9a-fA-F]{1,4}:){1,6})?[0-9a-fA-F]{1,4})?|::)$|^[A-Za-z0-9][A-Za-z0-9-]{0,63}(\\.[A-Za-z0-9-][A-Za-z0-9-]{0,63})*$",
+      "type": "string"
+    },
+    "^(constBool)$": {
+      "enum": [
+        false
+      ],
+      "type": "boolean"
+    },
+    "^(constDouble)$": {
+      "anyOf": [
+        {
+          "enum": [
+            5
+          ],
+          "type": "number"
+        },
+        {
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(constEnum)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "ENUM_VAL2"
+          ],
+          "title": "Enum",
+          "type": "string"
+        },
+        {
+          "enum": [
+            2
+          ],
+          "type": "integer"
+        }
+      ]
+    },
+    "^(constFixed32)$": {
+      "enum": [
+        5
+      ],
+      "exclusiveMaximum": 4294967296,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "^(constFixed64)$": {
+      "anyOf": [
+        {
+          "enum": [
+            5
+          ],
+          "exclusiveMaximum": 18446744073709552000,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(constFloat)$": {
+      "anyOf": [
+        {
+          "enum": [
+            5
+          ],
+          "maximum": 3.4028234663852886e+38,
+          "minimum": -3.4028234663852886e+38,
+          "type": "number"
+        },
+        {
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(constInt32)$": {
+      "enum": [
+        5
+      ],
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(constInt64)$": {
+      "anyOf": [
+        {
+          "enum": [
+            5
+          ],
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(constSfixed32)$": {
+      "enum": [
+        5
+      ],
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(constSfixed64)$": {
+      "anyOf": [
+        {
+          "enum": [
+            5
+          ],
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(constSint32)$": {
+      "enum": [
+        5
+      ],
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(constSint64)$": {
+      "anyOf": [
+        {
+          "enum": [
+            5
+          ],
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(constString)$": {
+      "enum": [
+        "const"
+      ],
+      "type": "string"
+    },
+    "^(constUint32)$": {
+      "enum": [
+        5
+      ],
+      "exclusiveMaximum": 4294967296,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "^(constUint64)$": {
+      "anyOf": [
+        {
+          "enum": [
+            5
+          ],
+          "exclusiveMaximum": 18446744073709552000,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(containsString)$": {
+      "pattern": ".*_contains_.*",
+      "type": "string"
+    },
+    "^(definedOnlyEnum)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "ENUM_UNSPECIFIED",
+            "ENUM_VAL1",
+            "ENUM_VAL2",
+            "ENUM_VAL7"
+          ],
+          "title": "Enum",
+          "type": "string"
+        },
+        {
+          "enum": [
+            0,
+            1,
+            2,
+            7
+          ],
+          "type": "integer"
+        }
+      ]
+    },
+    "^(definedOnlyNotInEnum)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "ENUM_VAL1",
+            "ENUM_VAL2",
+            "ENUM_VAL7"
+          ],
+          "title": "Enum",
+          "type": "string"
+        },
+        {
+          "enum": [
+            1,
+            2,
+            7
+          ],
+          "type": "integer"
+        }
+      ]
+    },
+    "^(emailString)$": {
+      "format": "email",
+      "type": "string"
+    },
+    "^(finiteDouble)$": {
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(finiteFloat)$": {
+      "anyOf": [
+        {
+          "maximum": 3.4028234663852886e+38,
+          "minimum": -3.4028234663852886e+38,
+          "type": "number"
+        },
+        {
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(gtDouble)$": {
+      "anyOf": [
+        {
+          "exclusiveMinimum": 5,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "^(gtFixed32)$": {
+      "exclusiveMaximum": 4294967296,
+      "exclusiveMinimum": 5,
+      "type": "integer"
+    },
+    "^(gtFixed64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 18446744073709552000,
+          "exclusiveMinimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(gtFloat)$": {
+      "anyOf": [
+        {
+          "exclusiveMinimum": 5,
+          "maximum": 3.4028234663852886e+38,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "^(gtInt32)$": {
+      "exclusiveMaximum": 2147483648,
+      "exclusiveMinimum": 5,
+      "type": "integer"
+    },
+    "^(gtInt64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "exclusiveMinimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(gtSfixed32)$": {
+      "exclusiveMaximum": 2147483648,
+      "exclusiveMinimum": 5,
+      "type": "integer"
+    },
+    "^(gtSfixed64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "exclusiveMinimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(gtSint32)$": {
+      "exclusiveMaximum": 2147483648,
+      "exclusiveMinimum": 5,
+      "type": "integer"
+    },
+    "^(gtSint64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "exclusiveMinimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(gtUint32)$": {
+      "exclusiveMaximum": 4294967296,
+      "exclusiveMinimum": 5,
+      "type": "integer"
+    },
+    "^(gtUint64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 18446744073709552000,
+          "exclusiveMinimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(gteDouble)$": {
+      "anyOf": [
+        {
+          "minimum": 5,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "^(gteFixed32)$": {
+      "exclusiveMaximum": 4294967296,
+      "minimum": 5,
+      "type": "integer"
+    },
+    "^(gteFixed64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 18446744073709552000,
+          "minimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(gteFloat)$": {
+      "anyOf": [
+        {
+          "maximum": 3.4028234663852886e+38,
+          "minimum": 5,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "^(gteInt32)$": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": 5,
+      "type": "integer"
+    },
+    "^(gteInt64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(gteSfixed32)$": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": 5,
+      "type": "integer"
+    },
+    "^(gteSfixed64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(gteSint32)$": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": 5,
+      "type": "integer"
+    },
+    "^(gteSint64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(gteUint32)$": {
+      "exclusiveMaximum": 4294967296,
+      "minimum": 5,
+      "type": "integer"
+    },
+    "^(gteUint64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 18446744073709552000,
+          "minimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(hostAndPortString)$": {
+      "pattern": "^([A-Za-z0-9][A-Za-z0-9-]{0,63}(\\.[A-Za-z0-9-][A-Za-z0-9-]{0,63})*|((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)|\\[(([0-9a-fA-F]{1,4}::?){1,7}([0-9a-fA-F]{1,4})|([0-9a-fA-F]{1,4}:){1,7}:|:((([0-9a-fA-F]{1,4}:){1,6})?[0-9a-fA-F]{1,4})?|::)\\]):([1-9][0-9]{0,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$",
+      "type": "string"
+    },
+    "^(hostnameString)$": {
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9-]{0,63}(\\.[A-Za-z0-9-][A-Za-z0-9-]{0,63})*$",
+      "type": "string"
+    },
+    "^(httpHeaderNameStrictString)$": {
+      "pattern": "^:?[0-9a-zA-Z!#$%\u0026\\'*+-.^_|~\\x60]+$",
+      "type": "string"
+    },
+    "^(inAndNotInEnum)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "ENUM_VAL1"
+          ],
+          "title": "Enum",
+          "type": "string"
+        },
+        {
+          "enum": [
+            1
+          ],
+          "type": "integer"
+        }
+      ]
+    },
+    "^(inDouble)$": {
+      "anyOf": [
+        {
+          "enum": [
+            1,
+            2
+          ],
+          "type": "number"
+        },
+        {
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(inEnum)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "ENUM_VAL1",
+            "ENUM_VAL2"
+          ],
+          "title": "Enum",
+          "type": "string"
+        },
+        {
+          "enum": [
+            1,
+            2
+          ],
+          "type": "integer"
+        }
+      ]
+    },
+    "^(inFixed32)$": {
+      "enum": [
+        1,
+        2
+      ],
+      "exclusiveMaximum": 4294967296,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "^(inFixed64)$": {
+      "anyOf": [
+        {
+          "enum": [
+            1,
+            2
+          ],
+          "exclusiveMaximum": 18446744073709552000,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(inFloat)$": {
+      "anyOf": [
+        {
+          "enum": [
+            1,
+            2
+          ],
+          "maximum": 3.4028234663852886e+38,
+          "minimum": -3.4028234663852886e+38,
+          "type": "number"
+        },
+        {
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(inInt32)$": {
+      "enum": [
+        1,
+        2
+      ],
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(inInt64)$": {
+      "anyOf": [
+        {
+          "enum": [
+            1,
+            2
+          ],
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(inMap)$": {
+      "additionalProperties": {
+        "enum": [
+          "value1",
+          "value2"
+        ],
+        "type": "string"
+      },
+      "propertyNames": {
+        "enum": [
+          "key1",
+          "key2"
+        ],
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(inSfixed32)$": {
+      "enum": [
+        1,
+        2
+      ],
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(inSfixed64)$": {
+      "anyOf": [
+        {
+          "enum": [
+            1,
+            2
+          ],
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(inSint32)$": {
+      "enum": [
+        1,
+        2
+      ],
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(inSint64)$": {
+      "anyOf": [
+        {
+          "enum": [
+            1,
+            2
+          ],
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(inString)$": {
+      "enum": [
+        "in1",
+        "in2"
+      ],
+      "type": "string"
+    },
+    "^(inUint32)$": {
+      "enum": [
+        1,
+        2
+      ],
+      "exclusiveMaximum": 4294967296,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "^(inUint64)$": {
+      "anyOf": [
+        {
+          "enum": [
+            1,
+            2
+          ],
+          "exclusiveMaximum": 18446744073709552000,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(ipPrefixString)$": {
+      "pattern": "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}0/([0-9]|[12][0-9]|3[0-2])$|^(([0-9a-fA-F]{1,4}:){1,7}:|::)/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$",
+      "type": "string"
+    },
+    "^(ipString)$": {
+      "pattern": "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$|^(([0-9a-fA-F]{1,4}::?){1,7}([0-9a-fA-F]{1,4})|([0-9a-fA-F]{1,4}:){1,7}:|:((([0-9a-fA-F]{1,4}:){1,6})?[0-9a-fA-F]{1,4})?|::)$",
+      "type": "string"
+    },
+    "^(ipWithPrefixlenString)$": {
+      "pattern": "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/([0-9]|[12][0-9]|3[0-2])$|^(([0-9a-fA-F]{1,4}::?){1,7}([0-9a-fA-F]{1,4})|([0-9a-fA-F]{1,4}:){1,7}:|:((([0-9a-fA-F]{1,4}:){1,6})?[0-9a-fA-F]{1,4})?|::)/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$",
+      "type": "string"
+    },
+    "^(ipv4PrefixString)$": {
+      "pattern": "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}0/([0-9]|[12][0-9]|3[0-2])$",
+      "type": "string"
+    },
+    "^(ipv4String)$": {
+      "format": "ipv4",
+      "type": "string"
+    },
+    "^(ipv4WithPrefixlenString)$": {
+      "pattern": "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/([0-9]|[12][0-9]|3[0-2])$",
+      "type": "string"
+    },
+    "^(ipv6PrefixString)$": {
+      "pattern": "^(([0-9a-fA-F]{1,4}:){1,7}:|::)/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$",
+      "type": "string"
+    },
+    "^(ipv6String)$": {
+      "format": "ipv6",
+      "type": "string"
+    },
+    "^(ipv6WithPrefixlenString)$": {
+      "pattern": "^(([0-9a-fA-F]{1,4}::?){1,7}([0-9a-fA-F]{1,4})|([0-9a-fA-F]{1,4}:){1,7}:|:((([0-9a-fA-F]{1,4}:){1,6})?[0-9a-fA-F]{1,4})?|::)/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$",
+      "type": "string"
+    },
+    "^(lenBytes)$": {
+      "maxLength": 8,
+      "minLength": 7,
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "^(lenString)$": {
+      "maxLength": 5,
+      "minLength": 5,
+      "type": "string"
+    },
+    "^(ltDouble)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 5,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "-Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "^(ltFixed32)$": {
+      "exclusiveMaximum": 5,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "^(ltFixed64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 5,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(ltFloat)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 5,
+          "minimum": -3.4028234663852886e+38,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "-Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "^(ltGtDouble)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 1,
+          "type": "number"
+        },
+        {
+          "exclusiveMinimum": 5,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "Infinity",
+            "-Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "^(ltGtFloat)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 1,
+          "type": "number"
+        },
+        {
+          "exclusiveMinimum": 5,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "Infinity",
+            "-Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "^(ltGtInt32)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 1,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        {
+          "exclusiveMaximum": 2147483648,
+          "exclusiveMinimum": 5,
+          "type": "integer"
+        }
+      ]
+    },
+    "^(ltGtInt64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 1,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "exclusiveMinimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(ltGtUint32)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 1,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "exclusiveMaximum": 4294967296,
+          "exclusiveMinimum": 5,
+          "type": "integer"
+        }
+      ]
+    },
+    "^(ltGtUint64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 1,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        },
+        {
+          "exclusiveMaximum": 18446744073709552000,
+          "exclusiveMinimum": 5,
+          "type": "integer"
+        }
+      ]
+    },
+    "^(ltInt32)$": {
+      "exclusiveMaximum": 5,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(ltInt64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 5,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(ltSfixed32)$": {
+      "exclusiveMaximum": 5,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(ltSfixed64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 5,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(ltSint32)$": {
+      "exclusiveMaximum": 5,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(ltSint64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 5,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(ltUint32)$": {
+      "exclusiveMaximum": 5,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "^(ltUint64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 5,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(lteDouble)$": {
+      "anyOf": [
+        {
+          "maximum": 5,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "-Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "^(lteFixed32)$": {
+      "maximum": 5,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "^(lteFixed64)$": {
+      "anyOf": [
+        {
+          "maximum": 5,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(lteFloat)$": {
+      "anyOf": [
+        {
+          "maximum": 5,
+          "minimum": -3.4028234663852886e+38,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "-Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "^(lteInt32)$": {
+      "maximum": 5,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(lteInt64)$": {
+      "anyOf": [
+        {
+          "maximum": 5,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(lteSfixed32)$": {
+      "maximum": 5,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(lteSfixed64)$": {
+      "anyOf": [
+        {
+          "maximum": 5,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(lteSint32)$": {
+      "maximum": 5,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(lteSint64)$": {
+      "anyOf": [
+        {
+          "maximum": 5,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(lteUint32)$": {
+      "maximum": 5,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "^(lteUint64)$": {
+      "anyOf": [
+        {
+          "maximum": 5,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(maxLenBytes)$": {
+      "maxLength": 8,
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "^(maxLenString)$": {
+      "maxLength": 5,
+      "type": "string"
+    },
+    "^(minLenBytes)$": {
+      "minLength": 7,
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "^(minLenString)$": {
+      "minLength": 5,
+      "type": "string"
+    },
+    "^(minMaxLenBytes)$": {
+      "maxLength": 16,
+      "minLength": 7,
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "^(minMaxLenString)$": {
+      "maxLength": 10,
+      "minLength": 5,
+      "type": "string"
+    },
+    "^(notInEnum)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "ENUM_VAL1",
+            "ENUM_VAL2"
+          ],
+          "title": "Enum",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "^(patternString)$": {
+      "pattern": "^pat*ern$",
+      "type": "string"
+    },
+    "^(prefixContainsSuffixString)$": {
+      "pattern": "^prefix_.*contains.*_suffix$",
+      "type": "string"
+    },
+    "^(prefixString)$": {
+      "pattern": "^prefix_.*",
+      "type": "string"
+    },
+    "^(prefixSuffixString)$": {
+      "pattern": "^prefix_.*_suffix$",
+      "type": "string"
+    },
+    "^(requiredImplicit)$": {
+      "$ref": "buf.protoschema.test.v1.ConstraintTest.RequiredImplicit.schema.json"
+    },
+    "^(requiredOptional)$": {
+      "$ref": "buf.protoschema.test.v1.ConstraintTest.RequiredOptional.schema.json"
+    },
+    "^(suffixString)$": {
+      "pattern": ".*_suffix$",
+      "type": "string"
+    },
+    "^(tuuidString)$": {
+      "pattern": "^[0-9a-fA-F]{32}$",
+      "type": "string"
+    },
+    "^(uriRefString)$": {
+      "pattern": "^(?:(?:[a-zA-Z][a-zA-Z\\d+\\-.]*):)?(?:\\/\\/(?:[A-Za-z0-9\\-\\.]+(?::\\d+)?))?(/[^\\?#]*)?(?:\\?([^\\#]*))?(?:\\#(.*))?$",
+      "type": "string"
+    },
+    "^(uriString)$": {
+      "pattern": "^(?:(?:[a-zA-Z][a-zA-Z\\d+\\-.]*):)?(?://(?:[A-Za-z0-9\\-\\.]+(?::\\d+)?))?(/[^\\?#]*)?(?:\\?([^\\#]*))?(?:\\#(.*))?$",
+      "type": "string"
+    },
+    "^(uuidString)$": {
+      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+      "type": "string"
+    }
+  },
+  "properties": {
+    "address_string": {
+      "pattern": "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$|^(([0-9a-fA-F]{1,4}::?){1,7}([0-9a-fA-F]{1,4})|([0-9a-fA-F]{1,4}:){1,7}:|:((([0-9a-fA-F]{1,4}:){1,6})?[0-9a-fA-F]{1,4})?|::)$|^[A-Za-z0-9][A-Za-z0-9-]{0,63}(\\.[A-Za-z0-9-][A-Za-z0-9-]{0,63})*$",
+      "type": "string"
+    },
+    "const_bool": {
+      "enum": [
+        false
+      ],
+      "type": "boolean"
+    },
+    "const_double": {
+      "anyOf": [
+        {
+          "enum": [
+            5
+          ],
+          "type": "number"
+        },
+        {
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
+          "type": "string"
+        }
+      ]
+    },
+    "const_enum": {
+      "anyOf": [
+        {
+          "enum": [
+            "ENUM_VAL2"
+          ],
+          "title": "Enum",
+          "type": "string"
+        },
+        {
+          "enum": [
+            2
+          ],
+          "type": "integer"
+        }
+      ]
+    },
+    "const_fixed32": {
+      "enum": [
+        5
+      ],
+      "exclusiveMaximum": 4294967296,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "const_fixed64": {
+      "anyOf": [
+        {
+          "enum": [
+            5
+          ],
+          "exclusiveMaximum": 18446744073709552000,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "const_float": {
+      "anyOf": [
+        {
+          "enum": [
+            5
+          ],
+          "maximum": 3.4028234663852886e+38,
+          "minimum": -3.4028234663852886e+38,
+          "type": "number"
+        },
+        {
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
+          "type": "string"
+        }
+      ]
+    },
+    "const_int32": {
+      "enum": [
+        5
+      ],
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "const_int64": {
+      "anyOf": [
+        {
+          "enum": [
+            5
+          ],
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "const_sfixed32": {
+      "enum": [
+        5
+      ],
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "const_sfixed64": {
+      "anyOf": [
+        {
+          "enum": [
+            5
+          ],
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "const_sint32": {
+      "enum": [
+        5
+      ],
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "const_sint64": {
+      "anyOf": [
+        {
+          "enum": [
+            5
+          ],
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "const_string": {
+      "enum": [
+        "const"
+      ],
+      "type": "string"
+    },
+    "const_uint32": {
+      "enum": [
+        5
+      ],
+      "exclusiveMaximum": 4294967296,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "const_uint64": {
+      "anyOf": [
+        {
+          "enum": [
+            5
+          ],
+          "exclusiveMaximum": 18446744073709552000,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "contains_string": {
+      "pattern": ".*_contains_.*",
+      "type": "string"
+    },
+    "defined_only_enum": {
+      "anyOf": [
+        {
+          "enum": [
+            "ENUM_UNSPECIFIED",
+            "ENUM_VAL1",
+            "ENUM_VAL2",
+            "ENUM_VAL7"
+          ],
+          "title": "Enum",
+          "type": "string"
+        },
+        {
+          "enum": [
+            0,
+            1,
+            2,
+            7
+          ],
+          "type": "integer"
+        }
+      ]
+    },
+    "defined_only_not_in_enum": {
+      "anyOf": [
+        {
+          "enum": [
+            "ENUM_VAL1",
+            "ENUM_VAL2",
+            "ENUM_VAL7"
+          ],
+          "title": "Enum",
+          "type": "string"
+        },
+        {
+          "enum": [
+            1,
+            2,
+            7
+          ],
+          "type": "integer"
+        }
+      ]
+    },
+    "email_string": {
+      "format": "email",
+      "type": "string"
+    },
+    "finite_double": {
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
+          "type": "string"
+        }
+      ]
+    },
+    "finite_float": {
+      "anyOf": [
+        {
+          "maximum": 3.4028234663852886e+38,
+          "minimum": -3.4028234663852886e+38,
+          "type": "number"
+        },
+        {
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
+          "type": "string"
+        }
+      ]
+    },
+    "gt_double": {
+      "anyOf": [
+        {
+          "exclusiveMinimum": 5,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "gt_fixed32": {
+      "exclusiveMaximum": 4294967296,
+      "exclusiveMinimum": 5,
+      "type": "integer"
+    },
+    "gt_fixed64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 18446744073709552000,
+          "exclusiveMinimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "gt_float": {
+      "anyOf": [
+        {
+          "exclusiveMinimum": 5,
+          "maximum": 3.4028234663852886e+38,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "gt_int32": {
+      "exclusiveMaximum": 2147483648,
+      "exclusiveMinimum": 5,
+      "type": "integer"
+    },
+    "gt_int64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "exclusiveMinimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "gt_sfixed32": {
+      "exclusiveMaximum": 2147483648,
+      "exclusiveMinimum": 5,
+      "type": "integer"
+    },
+    "gt_sfixed64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "exclusiveMinimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "gt_sint32": {
+      "exclusiveMaximum": 2147483648,
+      "exclusiveMinimum": 5,
+      "type": "integer"
+    },
+    "gt_sint64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "exclusiveMinimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "gt_uint32": {
+      "exclusiveMaximum": 4294967296,
+      "exclusiveMinimum": 5,
+      "type": "integer"
+    },
+    "gt_uint64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 18446744073709552000,
+          "exclusiveMinimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "gte_double": {
+      "anyOf": [
+        {
+          "minimum": 5,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "gte_fixed32": {
+      "exclusiveMaximum": 4294967296,
+      "minimum": 5,
+      "type": "integer"
+    },
+    "gte_fixed64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 18446744073709552000,
+          "minimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "gte_float": {
+      "anyOf": [
+        {
+          "maximum": 3.4028234663852886e+38,
+          "minimum": 5,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "gte_int32": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": 5,
+      "type": "integer"
+    },
+    "gte_int64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "gte_sfixed32": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": 5,
+      "type": "integer"
+    },
+    "gte_sfixed64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "gte_sint32": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": 5,
+      "type": "integer"
+    },
+    "gte_sint64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "gte_uint32": {
+      "exclusiveMaximum": 4294967296,
+      "minimum": 5,
+      "type": "integer"
+    },
+    "gte_uint64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 18446744073709552000,
+          "minimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "host_and_port_string": {
+      "pattern": "^([A-Za-z0-9][A-Za-z0-9-]{0,63}(\\.[A-Za-z0-9-][A-Za-z0-9-]{0,63})*|((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)|\\[(([0-9a-fA-F]{1,4}::?){1,7}([0-9a-fA-F]{1,4})|([0-9a-fA-F]{1,4}:){1,7}:|:((([0-9a-fA-F]{1,4}:){1,6})?[0-9a-fA-F]{1,4})?|::)\\]):([1-9][0-9]{0,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$",
+      "type": "string"
+    },
+    "hostname_string": {
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9-]{0,63}(\\.[A-Za-z0-9-][A-Za-z0-9-]{0,63})*$",
+      "type": "string"
+    },
+    "http_header_name_strict_string": {
+      "pattern": "^:?[0-9a-zA-Z!#$%\u0026\\'*+-.^_|~\\x60]+$",
+      "type": "string"
+    },
+    "in_and_not_in_enum": {
+      "anyOf": [
+        {
+          "enum": [
+            "ENUM_VAL1"
+          ],
+          "title": "Enum",
+          "type": "string"
+        },
+        {
+          "enum": [
+            1
+          ],
+          "type": "integer"
+        }
+      ]
+    },
+    "in_double": {
+      "anyOf": [
+        {
+          "enum": [
+            1,
+            2
+          ],
+          "type": "number"
+        },
+        {
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
+          "type": "string"
+        }
+      ]
+    },
+    "in_enum": {
+      "anyOf": [
+        {
+          "enum": [
+            "ENUM_VAL1",
+            "ENUM_VAL2"
+          ],
+          "title": "Enum",
+          "type": "string"
+        },
+        {
+          "enum": [
+            1,
+            2
+          ],
+          "type": "integer"
+        }
+      ]
+    },
+    "in_fixed32": {
+      "enum": [
+        1,
+        2
+      ],
+      "exclusiveMaximum": 4294967296,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "in_fixed64": {
+      "anyOf": [
+        {
+          "enum": [
+            1,
+            2
+          ],
+          "exclusiveMaximum": 18446744073709552000,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "in_float": {
+      "anyOf": [
+        {
+          "enum": [
+            1,
+            2
+          ],
+          "maximum": 3.4028234663852886e+38,
+          "minimum": -3.4028234663852886e+38,
+          "type": "number"
+        },
+        {
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
+          "type": "string"
+        }
+      ]
+    },
+    "in_int32": {
+      "enum": [
+        1,
+        2
+      ],
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "in_int64": {
+      "anyOf": [
+        {
+          "enum": [
+            1,
+            2
+          ],
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "in_map": {
+      "additionalProperties": {
+        "enum": [
+          "value1",
+          "value2"
+        ],
+        "type": "string"
+      },
+      "propertyNames": {
+        "enum": [
+          "key1",
+          "key2"
+        ],
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "in_sfixed32": {
+      "enum": [
+        1,
+        2
+      ],
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "in_sfixed64": {
+      "anyOf": [
+        {
+          "enum": [
+            1,
+            2
+          ],
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "in_sint32": {
+      "enum": [
+        1,
+        2
+      ],
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "in_sint64": {
+      "anyOf": [
+        {
+          "enum": [
+            1,
+            2
+          ],
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "in_string": {
+      "enum": [
+        "in1",
+        "in2"
+      ],
+      "type": "string"
+    },
+    "in_uint32": {
+      "enum": [
+        1,
+        2
+      ],
+      "exclusiveMaximum": 4294967296,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "in_uint64": {
+      "anyOf": [
+        {
+          "enum": [
+            1,
+            2
+          ],
+          "exclusiveMaximum": 18446744073709552000,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "ip_prefix_string": {
+      "pattern": "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}0/([0-9]|[12][0-9]|3[0-2])$|^(([0-9a-fA-F]{1,4}:){1,7}:|::)/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$",
+      "type": "string"
+    },
+    "ip_string": {
+      "pattern": "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$|^(([0-9a-fA-F]{1,4}::?){1,7}([0-9a-fA-F]{1,4})|([0-9a-fA-F]{1,4}:){1,7}:|:((([0-9a-fA-F]{1,4}:){1,6})?[0-9a-fA-F]{1,4})?|::)$",
+      "type": "string"
+    },
+    "ip_with_prefixlen_string": {
+      "pattern": "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/([0-9]|[12][0-9]|3[0-2])$|^(([0-9a-fA-F]{1,4}::?){1,7}([0-9a-fA-F]{1,4})|([0-9a-fA-F]{1,4}:){1,7}:|:((([0-9a-fA-F]{1,4}:){1,6})?[0-9a-fA-F]{1,4})?|::)/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$",
+      "type": "string"
+    },
+    "ipv4_prefix_string": {
+      "pattern": "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}0/([0-9]|[12][0-9]|3[0-2])$",
+      "type": "string"
+    },
+    "ipv4_string": {
+      "format": "ipv4",
+      "type": "string"
+    },
+    "ipv4_with_prefixlen_string": {
+      "pattern": "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/([0-9]|[12][0-9]|3[0-2])$",
+      "type": "string"
+    },
+    "ipv6_prefix_string": {
+      "pattern": "^(([0-9a-fA-F]{1,4}:){1,7}:|::)/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$",
+      "type": "string"
+    },
+    "ipv6_string": {
+      "format": "ipv6",
+      "type": "string"
+    },
+    "ipv6_with_prefixlen_string": {
+      "pattern": "^(([0-9a-fA-F]{1,4}::?){1,7}([0-9a-fA-F]{1,4})|([0-9a-fA-F]{1,4}:){1,7}:|:((([0-9a-fA-F]{1,4}:){1,6})?[0-9a-fA-F]{1,4})?|::)/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$",
+      "type": "string"
+    },
+    "len_bytes": {
+      "maxLength": 8,
+      "minLength": 7,
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "len_string": {
+      "maxLength": 5,
+      "minLength": 5,
+      "type": "string"
+    },
+    "lt_double": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 5,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "-Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "lt_fixed32": {
+      "exclusiveMaximum": 5,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "lt_fixed64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 5,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "lt_float": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 5,
+          "minimum": -3.4028234663852886e+38,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "-Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "lt_gt_double": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 1,
+          "type": "number"
+        },
+        {
+          "exclusiveMinimum": 5,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "Infinity",
+            "-Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "lt_gt_float": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 1,
+          "type": "number"
+        },
+        {
+          "exclusiveMinimum": 5,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "Infinity",
+            "-Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "lt_gt_int32": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 1,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        {
+          "exclusiveMaximum": 2147483648,
+          "exclusiveMinimum": 5,
+          "type": "integer"
+        }
+      ]
+    },
+    "lt_gt_int64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 1,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "exclusiveMinimum": 5,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "lt_gt_uint32": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 1,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "exclusiveMaximum": 4294967296,
+          "exclusiveMinimum": 5,
+          "type": "integer"
+        }
+      ]
+    },
+    "lt_gt_uint64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 1,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        },
+        {
+          "exclusiveMaximum": 18446744073709552000,
+          "exclusiveMinimum": 5,
+          "type": "integer"
+        }
+      ]
+    },
+    "lt_int32": {
+      "exclusiveMaximum": 5,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "lt_int64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 5,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "lt_sfixed32": {
+      "exclusiveMaximum": 5,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "lt_sfixed64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 5,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "lt_sint32": {
+      "exclusiveMaximum": 5,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "lt_sint64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 5,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "lt_uint32": {
+      "exclusiveMaximum": 5,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "lt_uint64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 5,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "lte_double": {
+      "anyOf": [
+        {
+          "maximum": 5,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "-Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "lte_fixed32": {
+      "maximum": 5,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "lte_fixed64": {
+      "anyOf": [
+        {
+          "maximum": 5,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "lte_float": {
+      "anyOf": [
+        {
+          "maximum": 5,
+          "minimum": -3.4028234663852886e+38,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "-Infinity"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "lte_int32": {
+      "maximum": 5,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "lte_int64": {
+      "anyOf": [
+        {
+          "maximum": 5,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "lte_sfixed32": {
+      "maximum": 5,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "lte_sfixed64": {
+      "anyOf": [
+        {
+          "maximum": 5,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "lte_sint32": {
+      "maximum": 5,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "lte_sint64": {
+      "anyOf": [
+        {
+          "maximum": 5,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "lte_uint32": {
+      "maximum": 5,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "lte_uint64": {
+      "anyOf": [
+        {
+          "maximum": 5,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "max_len_bytes": {
+      "maxLength": 8,
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "max_len_string": {
+      "maxLength": 5,
+      "type": "string"
+    },
+    "min_len_bytes": {
+      "minLength": 7,
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "min_len_string": {
+      "minLength": 5,
+      "type": "string"
+    },
+    "min_max_len_bytes": {
+      "maxLength": 16,
+      "minLength": 7,
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "min_max_len_string": {
+      "maxLength": 10,
+      "minLength": 5,
+      "type": "string"
+    },
+    "not_in_enum": {
+      "anyOf": [
+        {
+          "enum": [
+            "ENUM_VAL1",
+            "ENUM_VAL2"
+          ],
+          "title": "Enum",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "pattern_string": {
+      "pattern": "^pat*ern$",
+      "type": "string"
+    },
+    "prefix_contains_suffix_string": {
+      "pattern": "^prefix_.*contains.*_suffix$",
+      "type": "string"
+    },
+    "prefix_string": {
+      "pattern": "^prefix_.*",
+      "type": "string"
+    },
+    "prefix_suffix_string": {
+      "pattern": "^prefix_.*_suffix$",
+      "type": "string"
+    },
+    "required_implicit": {
+      "$ref": "buf.protoschema.test.v1.ConstraintTest.RequiredImplicit.schema.json"
+    },
+    "required_optional": {
+      "$ref": "buf.protoschema.test.v1.ConstraintTest.RequiredOptional.schema.json"
+    },
+    "suffix_string": {
+      "pattern": ".*_suffix$",
+      "type": "string"
+    },
+    "tuuid_string": {
+      "pattern": "^[0-9a-fA-F]{32}$",
+      "type": "string"
+    },
+    "uri_ref_string": {
+      "pattern": "^(?:(?:[a-zA-Z][a-zA-Z\\d+\\-.]*):)?(?:\\/\\/(?:[A-Za-z0-9\\-\\.]+(?::\\d+)?))?(/[^\\?#]*)?(?:\\?([^\\#]*))?(?:\\#(.*))?$",
+      "type": "string"
+    },
+    "uri_string": {
+      "pattern": "^(?:(?:[a-zA-Z][a-zA-Z\\d+\\-.]*):)?(?://(?:[A-Za-z0-9\\-\\.]+(?::\\d+)?))?(/[^\\?#]*)?(?:\\?([^\\#]*))?(?:\\#(.*))?$",
+      "type": "string"
+    },
+    "uuid_string": {
+      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+      "type": "string"
+    }
+  },
+  "title": "Constraint Test",
+  "type": "object"
+}

--- a/internal/gen/jsonschema/buf.protoschema.test.v1.ConstraintTests.jsonschema.json
+++ b/internal/gen/jsonschema/buf.protoschema.test.v1.ConstraintTests.jsonschema.json
@@ -1,0 +1,23 @@
+{
+  "$id": "buf.protoschema.test.v1.ConstraintTests.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "patternProperties": {
+    "^(test_cases)$": {
+      "items": {
+        "$ref": "buf.protoschema.test.v1.ConstraintTest.jsonschema.json"
+      },
+      "type": "array"
+    }
+  },
+  "properties": {
+    "testCases": {
+      "items": {
+        "$ref": "buf.protoschema.test.v1.ConstraintTest.jsonschema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "Constraint Tests",
+  "type": "object"
+}

--- a/internal/gen/jsonschema/buf.protoschema.test.v1.ConstraintTests.schema.json
+++ b/internal/gen/jsonschema/buf.protoschema.test.v1.ConstraintTests.schema.json
@@ -1,0 +1,23 @@
+{
+  "$id": "buf.protoschema.test.v1.ConstraintTests.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "patternProperties": {
+    "^(testCases)$": {
+      "items": {
+        "$ref": "buf.protoschema.test.v1.ConstraintTest.schema.json"
+      },
+      "type": "array"
+    }
+  },
+  "properties": {
+    "test_cases": {
+      "items": {
+        "$ref": "buf.protoschema.test.v1.ConstraintTest.schema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "Constraint Tests",
+  "type": "object"
+}

--- a/internal/gen/jsonschema/buf.protoschema.test.v1.CustomOptions.jsonschema.json
+++ b/internal/gen/jsonschema/buf.protoschema.test.v1.CustomOptions.jsonschema.json
@@ -1,0 +1,33 @@
+{
+  "$id": "buf.protoschema.test.v1.CustomOptions.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "patternProperties": {
+    "^(int32_field)$": {
+      "items": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "^(string_field)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "int32Field": {
+      "items": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "stringField": {
+      "type": "string"
+    }
+  },
+  "title": "Custom Options",
+  "type": "object"
+}

--- a/internal/gen/jsonschema/buf.protoschema.test.v1.CustomOptions.schema.json
+++ b/internal/gen/jsonschema/buf.protoschema.test.v1.CustomOptions.schema.json
@@ -1,0 +1,33 @@
+{
+  "$id": "buf.protoschema.test.v1.CustomOptions.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "patternProperties": {
+    "^(int32Field)$": {
+      "items": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "^(stringField)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "int32_field": {
+      "items": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "string_field": {
+      "type": "string"
+    }
+  },
+  "title": "Custom Options",
+  "type": "object"
+}

--- a/internal/gen/jsonschema/buf.protoschema.test.v1.IgnoreField.jsonschema.json
+++ b/internal/gen/jsonschema/buf.protoschema.test.v1.IgnoreField.jsonschema.json
@@ -1,0 +1,25 @@
+{
+  "$id": "buf.protoschema.test.v1.IgnoreField.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "patternProperties": {
+    "^(bool_field)$": {
+      "type": "boolean"
+    },
+    "^(bytes_field|bytesField)$": {
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "^(nested_reference|nestedReference)$": {
+      "$ref": "buf.protoschema.test.v1.NestedReference.jsonschema.json",
+      "description": "jsonschema:hide"
+    }
+  },
+  "properties": {
+    "boolField": {
+      "type": "boolean"
+    }
+  },
+  "title": "Ignore Field",
+  "type": "object"
+}

--- a/internal/gen/jsonschema/buf.protoschema.test.v1.IgnoreField.schema.json
+++ b/internal/gen/jsonschema/buf.protoschema.test.v1.IgnoreField.schema.json
@@ -1,0 +1,25 @@
+{
+  "$id": "buf.protoschema.test.v1.IgnoreField.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "patternProperties": {
+    "^(boolField)$": {
+      "type": "boolean"
+    },
+    "^(bytes_field|bytesField)$": {
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "^(nested_reference|nestedReference)$": {
+      "$ref": "buf.protoschema.test.v1.NestedReference.schema.json",
+      "description": "jsonschema:hide"
+    }
+  },
+  "properties": {
+    "bool_field": {
+      "type": "boolean"
+    }
+  },
+  "title": "Ignore Field",
+  "type": "object"
+}

--- a/internal/gen/jsonschema/buf.protoschema.test.v1.NestedReference.jsonschema.json
+++ b/internal/gen/jsonschema/buf.protoschema.test.v1.NestedReference.jsonschema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "buf.protoschema.test.v1.NestedReference.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "patternProperties": {
+    "^(nested_message)$": {
+      "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+    }
+  },
+  "properties": {
+    "nestedMessage": {
+      "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+    }
+  },
+  "title": "Nested Reference",
+  "type": "object"
+}

--- a/internal/gen/jsonschema/buf.protoschema.test.v1.NestedReference.schema.json
+++ b/internal/gen/jsonschema/buf.protoschema.test.v1.NestedReference.schema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "buf.protoschema.test.v1.NestedReference.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "patternProperties": {
+    "^(nestedMessage)$": {
+      "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.schema.json"
+    }
+  },
+  "properties": {
+    "nested_message": {
+      "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.schema.json"
+    }
+  },
+  "title": "Nested Reference",
+  "type": "object"
+}

--- a/internal/gen/jsonschema/bufext.cel.expr.conformance.proto3.NestedTestAllTypes.jsonschema.json
+++ b/internal/gen/jsonschema/bufext.cel.expr.conformance.proto3.NestedTestAllTypes.jsonschema.json
@@ -1,0 +1,16 @@
+{
+  "$id": "bufext.cel.expr.conformance.proto3.NestedTestAllTypes.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "description": "This proto includes a recursively nested message.",
+  "properties": {
+    "child": {
+      "$ref": "#"
+    },
+    "payload": {
+      "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.jsonschema.json"
+    }
+  },
+  "title": "Nested Test All Types",
+  "type": "object"
+}

--- a/internal/gen/jsonschema/bufext.cel.expr.conformance.proto3.NestedTestAllTypes.schema.json
+++ b/internal/gen/jsonschema/bufext.cel.expr.conformance.proto3.NestedTestAllTypes.schema.json
@@ -1,0 +1,16 @@
+{
+  "$id": "bufext.cel.expr.conformance.proto3.NestedTestAllTypes.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "description": "This proto includes a recursively nested message.",
+  "properties": {
+    "child": {
+      "$ref": "#"
+    },
+    "payload": {
+      "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.schema.json"
+    }
+  },
+  "title": "Nested Test All Types",
+  "type": "object"
+}

--- a/internal/gen/jsonschema/bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json
+++ b/internal/gen/jsonschema/bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "properties": {
+    "bb": {
+      "description": "The field name \"b\" fails to compile in proto1 because it conflicts with\n a local variable named \"b\" in one of the generated methods.\n This file needs to compile in proto1 to test backwards-compatibility.",
+      "maximum": 2147483647,
+      "minimum": -2147483648,
+      "type": "integer"
+    }
+  },
+  "title": "Nested Message",
+  "type": "object"
+}

--- a/internal/gen/jsonschema/bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.schema.json
+++ b/internal/gen/jsonschema/bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.schema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "properties": {
+    "bb": {
+      "description": "The field name \"b\" fails to compile in proto1 because it conflicts with\n a local variable named \"b\" in one of the generated methods.\n This file needs to compile in proto1 to test backwards-compatibility.",
+      "maximum": 2147483647,
+      "minimum": -2147483648,
+      "type": "integer"
+    }
+  },
+  "title": "Nested Message",
+  "type": "object"
+}

--- a/internal/gen/jsonschema/bufext.cel.expr.conformance.proto3.TestAllTypes.jsonschema.json
+++ b/internal/gen/jsonschema/bufext.cel.expr.conformance.proto3.TestAllTypes.jsonschema.json
@@ -1,0 +1,6482 @@
+{
+  "$id": "bufext.cel.expr.conformance.proto3.TestAllTypes.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "description": "This proto includes every type of field in both singular and repeated\n forms.",
+  "patternProperties": {
+    "^(list_value)$": {
+      "$ref": "google.protobuf.ListValue.jsonschema.json"
+    },
+    "^(map_bool_any)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Any.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_bool)$": {
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_bool_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BoolValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_bytes)$": {
+      "additionalProperties": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_bytes_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BytesValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_double)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_double_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.DoubleValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_duration)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Duration.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_enum)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_float)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "maximum": 3.4028234663852886e+38,
+            "minimum": -3.4028234663852886e+38,
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_float_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.FloatValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_int32)$": {
+      "additionalProperties": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_int32_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_int64)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_int64_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_list_value)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.ListValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_message)$": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_null_value)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_string)$": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_string_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.StringValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_struct)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Struct.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_timestamp)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Timestamp.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_uint32)$": {
+      "additionalProperties": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_uint32_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_uint64)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_uint64_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_bool_value)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(map_int32_any)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Any.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_bool)$": {
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_bool_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BoolValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_bytes)$": {
+      "additionalProperties": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_bytes_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BytesValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_double)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_double_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.DoubleValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_duration)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Duration.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_enum)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_float)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "maximum": 3.4028234663852886e+38,
+            "minimum": -3.4028234663852886e+38,
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_float_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.FloatValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_int32)$": {
+      "additionalProperties": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_int32_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_int64)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_int64_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_list_value)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.ListValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_message)$": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_null_value)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_string)$": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_string_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.StringValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_struct)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Struct.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_timestamp)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Timestamp.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_uint32)$": {
+      "additionalProperties": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_uint32_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_uint64)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_uint64_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int32_value)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_int64_any)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Any.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_bool)$": {
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_bool_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BoolValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_bytes)$": {
+      "additionalProperties": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_bytes_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BytesValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_double)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_double_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.DoubleValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_duration)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Duration.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_enum)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_float)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "maximum": 3.4028234663852886e+38,
+            "minimum": -3.4028234663852886e+38,
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_float_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.FloatValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_int32)$": {
+      "additionalProperties": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_int32_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_int64)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_int64_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_list_value)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.ListValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_message)$": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_nested_type)$": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.NestedTestAllTypes.jsonschema.json"
+      },
+      "description": "Map",
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_null_value)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_string)$": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_string_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.StringValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_struct)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Struct.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_timestamp)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Timestamp.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_uint32)$": {
+      "additionalProperties": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_uint32_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_uint64)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_uint64_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_int64_value)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_string_any)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Any.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_bool)$": {
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_bool_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BoolValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_bytes)$": {
+      "additionalProperties": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_bytes_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BytesValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_double)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_double_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.DoubleValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_duration)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Duration.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_enum)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_float)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "maximum": 3.4028234663852886e+38,
+            "minimum": -3.4028234663852886e+38,
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_float_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.FloatValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_int32)$": {
+      "additionalProperties": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_int32_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_int64)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_int64_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_list_value)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.ListValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_message)$": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_null_value)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_string)$": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_string_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.StringValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_struct)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Struct.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_timestamp)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Timestamp.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_uint32)$": {
+      "additionalProperties": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_uint32_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_uint64)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_uint64_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_string_value)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_any)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Any.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_bool)$": {
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_bool_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BoolValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_bytes)$": {
+      "additionalProperties": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_bytes_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BytesValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_double)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_double_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.DoubleValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_duration)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Duration.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_enum)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_float)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "maximum": 3.4028234663852886e+38,
+            "minimum": -3.4028234663852886e+38,
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_float_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.FloatValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_int32)$": {
+      "additionalProperties": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_int32_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_int64)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_int64_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_list_value)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.ListValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_message)$": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_null_value)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_string)$": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_string_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.StringValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_struct)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Struct.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_timestamp)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Timestamp.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_uint32)$": {
+      "additionalProperties": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_uint32_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_uint64)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_uint64_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint32_value)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(map_uint64_any)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Any.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_uint64_bool)$": {
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_uint64_bool_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BoolValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_uint64_bytes)$": {
+      "additionalProperties": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_uint64_bytes_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BytesValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_uint64_double)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_uint64_double_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.DoubleValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_uint64_duration)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Duration.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_uint64_enum)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_uint64_float)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "maximum": 3.4028234663852886e+38,
+            "minimum": -3.4028234663852886e+38,
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_uint64_float_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.FloatValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_uint64_int32)$": {
+      "additionalProperties": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_uint64_int32_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_uint64_int64)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_uint64_int64_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_uint64_list_value)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.ListValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_uint64_message)$": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_uint64_null_value)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_uint64_string)$": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_uint64_string_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.StringValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_uint64_struct)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Struct.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_uint64_timestamp)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Timestamp.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_uint64_uint32)$": {
+      "additionalProperties": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_uint64_uint32_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_uint64_uint64)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_uint64_uint64_wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(map_uint64_value)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(null_value)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "NULL_VALUE"
+          ],
+          "title": "Null Value",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "^(optional_null_value)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "NULL_VALUE"
+          ],
+          "title": "Null Value",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "^(repeated_any)$": {
+      "description": "Repeated wellknown.",
+      "items": {
+        "$ref": "google.protobuf.Any.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "^(repeated_bool)$": {
+      "items": {
+        "type": "boolean"
+      },
+      "type": "array"
+    },
+    "^(repeated_bool_wrapper)$": {
+      "items": {
+        "$ref": "google.protobuf.BoolValue.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "^(repeated_bytes)$": {
+      "items": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "^(repeated_bytes_wrapper)$": {
+      "items": {
+        "$ref": "google.protobuf.BytesValue.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "^(repeated_cord)$": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "^(repeated_double)$": {
+      "items": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "^(repeated_double_wrapper)$": {
+      "items": {
+        "$ref": "google.protobuf.DoubleValue.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "^(repeated_duration)$": {
+      "items": {
+        "$ref": "google.protobuf.Duration.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "^(repeated_fixed32)$": {
+      "items": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "^(repeated_fixed64)$": {
+      "items": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "^(repeated_float)$": {
+      "items": {
+        "anyOf": [
+          {
+            "maximum": 3.4028234663852886e+38,
+            "minimum": -3.4028234663852886e+38,
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "^(repeated_float_wrapper)$": {
+      "items": {
+        "$ref": "google.protobuf.FloatValue.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "^(repeated_int32)$": {
+      "description": "Repeated",
+      "items": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "^(repeated_int32_wrapper)$": {
+      "items": {
+        "$ref": "google.protobuf.Int32Value.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "^(repeated_int64)$": {
+      "items": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "^(repeated_int64_wrapper)$": {
+      "items": {
+        "$ref": "google.protobuf.Int64Value.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "^(repeated_lazy_message)$": {
+      "items": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "^(repeated_list_value)$": {
+      "items": {
+        "$ref": "google.protobuf.ListValue.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "^(repeated_nested_enum)$": {
+      "items": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "^(repeated_nested_message)$": {
+      "description": "Repeated and nested",
+      "items": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "^(repeated_null_value)$": {
+      "items": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "^(repeated_sfixed32)$": {
+      "items": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "^(repeated_sfixed64)$": {
+      "items": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "^(repeated_sint32)$": {
+      "items": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "^(repeated_sint64)$": {
+      "items": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "^(repeated_string)$": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "^(repeated_string_piece)$": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "^(repeated_string_wrapper)$": {
+      "items": {
+        "$ref": "google.protobuf.StringValue.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "^(repeated_struct)$": {
+      "items": {
+        "$ref": "google.protobuf.Struct.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "^(repeated_timestamp)$": {
+      "items": {
+        "$ref": "google.protobuf.Timestamp.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "^(repeated_uint32)$": {
+      "items": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "^(repeated_uint32_wrapper)$": {
+      "items": {
+        "$ref": "google.protobuf.UInt32Value.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "^(repeated_uint64)$": {
+      "items": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "^(repeated_uint64_wrapper)$": {
+      "items": {
+        "$ref": "google.protobuf.UInt64Value.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "^(repeated_value)$": {
+      "items": {
+        "$ref": "google.protobuf.Value.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "^(single_any)$": {
+      "$ref": "google.protobuf.Any.jsonschema.json",
+      "description": "Wellknown."
+    },
+    "^(single_bool)$": {
+      "type": "boolean"
+    },
+    "^(single_bool_wrapper)$": {
+      "$ref": "google.protobuf.BoolValue.jsonschema.json"
+    },
+    "^(single_bytes)$": {
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "^(single_bytes_wrapper)$": {
+      "$ref": "google.protobuf.BytesValue.jsonschema.json"
+    },
+    "^(single_double)$": {
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "enum": [
+            "Infinity",
+            "-Infinity",
+            "NaN"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "^(single_double_wrapper)$": {
+      "$ref": "google.protobuf.DoubleValue.jsonschema.json"
+    },
+    "^(single_duration)$": {
+      "$ref": "google.protobuf.Duration.jsonschema.json"
+    },
+    "^(single_fixed32)$": {
+      "maximum": 4294967295,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "^(single_fixed64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 18446744073709551616,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(single_float)$": {
+      "anyOf": [
+        {
+          "maximum": 3.4028234663852886e+38,
+          "minimum": -3.4028234663852886e+38,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "Infinity",
+            "-Infinity",
+            "NaN"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "^(single_float_wrapper)$": {
+      "$ref": "google.protobuf.FloatValue.jsonschema.json"
+    },
+    "^(single_int32)$": {
+      "description": "Singular",
+      "maximum": 2147483647,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(single_int32_wrapper)$": {
+      "$ref": "google.protobuf.Int32Value.jsonschema.json"
+    },
+    "^(single_int64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(single_int64_wrapper)$": {
+      "$ref": "google.protobuf.Int64Value.jsonschema.json"
+    },
+    "^(single_nested_enum)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "FOO",
+            "BAR",
+            "BAZ"
+          ],
+          "title": "Nested Enum",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "^(single_nested_message)$": {
+      "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+    },
+    "^(single_sfixed32)$": {
+      "maximum": 2147483647,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(single_sfixed64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(single_sint32)$": {
+      "maximum": 2147483647,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(single_sint64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(single_string)$": {
+      "type": "string"
+    },
+    "^(single_string_wrapper)$": {
+      "$ref": "google.protobuf.StringValue.jsonschema.json"
+    },
+    "^(single_struct)$": {
+      "$ref": "google.protobuf.Struct.jsonschema.json"
+    },
+    "^(single_timestamp)$": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "^(single_uint32)$": {
+      "maximum": 4294967295,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "^(single_uint32_wrapper)$": {
+      "$ref": "google.protobuf.UInt32Value.jsonschema.json"
+    },
+    "^(single_uint64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 18446744073709551616,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(single_uint64_wrapper)$": {
+      "$ref": "google.protobuf.UInt64Value.jsonschema.json"
+    },
+    "^(single_value)$": {
+      "$ref": "google.protobuf.Value.jsonschema.json"
+    },
+    "^(standalone_enum)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "FOO",
+            "BAR",
+            "BAZ"
+          ],
+          "title": "Nested Enum",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "^(standalone_message)$": {
+      "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+    }
+  },
+  "properties": {
+    "listValue": {
+      "$ref": "google.protobuf.ListValue.jsonschema.json"
+    },
+    "mapBoolAny": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Any.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolBool": {
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolBoolWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BoolValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolBytes": {
+      "additionalProperties": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolBytesWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BytesValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolDouble": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolDoubleWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.DoubleValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolDuration": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Duration.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolEnum": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolFloat": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "maximum": 3.4028234663852886e+38,
+            "minimum": -3.4028234663852886e+38,
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolFloatWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.FloatValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolInt32": {
+      "additionalProperties": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolInt32Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolInt64": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolInt64Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolListValue": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.ListValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolMessage": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolNullValue": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolString": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolStringWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.StringValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolStruct": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Struct.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolTimestamp": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Timestamp.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolUint32": {
+      "additionalProperties": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolUint32Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolUint64": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolUint64Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapBoolValue": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "mapInt32Any": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Any.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32Bool": {
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32BoolWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BoolValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32Bytes": {
+      "additionalProperties": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32BytesWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BytesValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32Double": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32DoubleWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.DoubleValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32Duration": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Duration.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32Enum": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32Float": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "maximum": 3.4028234663852886e+38,
+            "minimum": -3.4028234663852886e+38,
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32FloatWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.FloatValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32Int32": {
+      "additionalProperties": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32Int32Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32Int64": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32Int64Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32ListValue": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.ListValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32Message": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32NullValue": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32String": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32StringWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.StringValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32Struct": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Struct.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32Timestamp": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Timestamp.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32Uint32": {
+      "additionalProperties": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32Uint32Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32Uint64": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32Uint64Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt32Value": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapInt64Any": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Any.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64Bool": {
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64BoolWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BoolValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64Bytes": {
+      "additionalProperties": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64BytesWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BytesValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64Double": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64DoubleWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.DoubleValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64Duration": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Duration.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64Enum": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64Float": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "maximum": 3.4028234663852886e+38,
+            "minimum": -3.4028234663852886e+38,
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64FloatWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.FloatValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64Int32": {
+      "additionalProperties": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64Int32Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64Int64": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64Int64Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64ListValue": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.ListValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64Message": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64NestedType": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.NestedTestAllTypes.jsonschema.json"
+      },
+      "description": "Map",
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64NullValue": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64String": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64StringWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.StringValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64Struct": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Struct.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64Timestamp": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Timestamp.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64Uint32": {
+      "additionalProperties": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64Uint32Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64Uint64": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64Uint64Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapInt64Value": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapStringAny": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Any.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringBool": {
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringBoolWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BoolValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringBytes": {
+      "additionalProperties": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringBytesWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BytesValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringDouble": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringDoubleWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.DoubleValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringDuration": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Duration.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringEnum": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringFloat": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "maximum": 3.4028234663852886e+38,
+            "minimum": -3.4028234663852886e+38,
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringFloatWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.FloatValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringInt32": {
+      "additionalProperties": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringInt32Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringInt64": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringInt64Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringListValue": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.ListValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringMessage": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringNullValue": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringString": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringStringWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.StringValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringStruct": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Struct.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringTimestamp": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Timestamp.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringUint32": {
+      "additionalProperties": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringUint32Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringUint64": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringUint64Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapStringValue": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "mapUint32Any": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Any.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32Bool": {
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32BoolWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BoolValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32Bytes": {
+      "additionalProperties": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32BytesWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BytesValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32Double": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32DoubleWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.DoubleValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32Duration": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Duration.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32Enum": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32Float": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "maximum": 3.4028234663852886e+38,
+            "minimum": -3.4028234663852886e+38,
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32FloatWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.FloatValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32Int32": {
+      "additionalProperties": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32Int32Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32Int64": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32Int64Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32ListValue": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.ListValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32Message": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32NullValue": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32String": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32StringWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.StringValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32Struct": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Struct.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32Timestamp": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Timestamp.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32Uint32": {
+      "additionalProperties": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32Uint32Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32Uint64": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32Uint64Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint32Value": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "mapUint64Any": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Any.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapUint64Bool": {
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapUint64BoolWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BoolValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapUint64Bytes": {
+      "additionalProperties": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapUint64BytesWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BytesValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapUint64Double": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapUint64DoubleWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.DoubleValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapUint64Duration": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Duration.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapUint64Enum": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapUint64Float": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "maximum": 3.4028234663852886e+38,
+            "minimum": -3.4028234663852886e+38,
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapUint64FloatWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.FloatValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapUint64Int32": {
+      "additionalProperties": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapUint64Int32Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapUint64Int64": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapUint64Int64Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapUint64ListValue": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.ListValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapUint64Message": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapUint64NullValue": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapUint64String": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapUint64StringWrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.StringValue.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapUint64Struct": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Struct.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapUint64Timestamp": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Timestamp.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapUint64Uint32": {
+      "additionalProperties": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapUint64Uint32Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt32Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapUint64Uint64": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapUint64Uint64Wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt64Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "mapUint64Value": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Value.jsonschema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "nullValue": {
+      "anyOf": [
+        {
+          "enum": [
+            "NULL_VALUE"
+          ],
+          "title": "Null Value",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "optionalNullValue": {
+      "anyOf": [
+        {
+          "enum": [
+            "NULL_VALUE"
+          ],
+          "title": "Null Value",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "repeatedAny": {
+      "description": "Repeated wellknown.",
+      "items": {
+        "$ref": "google.protobuf.Any.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "repeatedBool": {
+      "items": {
+        "type": "boolean"
+      },
+      "type": "array"
+    },
+    "repeatedBoolWrapper": {
+      "items": {
+        "$ref": "google.protobuf.BoolValue.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "repeatedBytes": {
+      "items": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "repeatedBytesWrapper": {
+      "items": {
+        "$ref": "google.protobuf.BytesValue.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "repeatedCord": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "repeatedDouble": {
+      "items": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "repeatedDoubleWrapper": {
+      "items": {
+        "$ref": "google.protobuf.DoubleValue.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "repeatedDuration": {
+      "items": {
+        "$ref": "google.protobuf.Duration.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "repeatedFixed32": {
+      "items": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "repeatedFixed64": {
+      "items": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "repeatedFloat": {
+      "items": {
+        "anyOf": [
+          {
+            "maximum": 3.4028234663852886e+38,
+            "minimum": -3.4028234663852886e+38,
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "repeatedFloatWrapper": {
+      "items": {
+        "$ref": "google.protobuf.FloatValue.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "repeatedInt32": {
+      "description": "Repeated",
+      "items": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "repeatedInt32Wrapper": {
+      "items": {
+        "$ref": "google.protobuf.Int32Value.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "repeatedInt64": {
+      "items": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "repeatedInt64Wrapper": {
+      "items": {
+        "$ref": "google.protobuf.Int64Value.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "repeatedLazyMessage": {
+      "items": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "repeatedListValue": {
+      "items": {
+        "$ref": "google.protobuf.ListValue.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "repeatedNestedEnum": {
+      "items": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "repeatedNestedMessage": {
+      "description": "Repeated and nested",
+      "items": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "repeatedNullValue": {
+      "items": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "repeatedSfixed32": {
+      "items": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "repeatedSfixed64": {
+      "items": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "repeatedSint32": {
+      "items": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "repeatedSint64": {
+      "items": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "repeatedString": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "repeatedStringPiece": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "repeatedStringWrapper": {
+      "items": {
+        "$ref": "google.protobuf.StringValue.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "repeatedStruct": {
+      "items": {
+        "$ref": "google.protobuf.Struct.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "repeatedTimestamp": {
+      "items": {
+        "$ref": "google.protobuf.Timestamp.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "repeatedUint32": {
+      "items": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "repeatedUint32Wrapper": {
+      "items": {
+        "$ref": "google.protobuf.UInt32Value.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "repeatedUint64": {
+      "items": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "repeatedUint64Wrapper": {
+      "items": {
+        "$ref": "google.protobuf.UInt64Value.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "repeatedValue": {
+      "items": {
+        "$ref": "google.protobuf.Value.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "singleAny": {
+      "$ref": "google.protobuf.Any.jsonschema.json",
+      "description": "Wellknown."
+    },
+    "singleBool": {
+      "type": "boolean"
+    },
+    "singleBoolWrapper": {
+      "$ref": "google.protobuf.BoolValue.jsonschema.json"
+    },
+    "singleBytes": {
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "singleBytesWrapper": {
+      "$ref": "google.protobuf.BytesValue.jsonschema.json"
+    },
+    "singleDouble": {
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "enum": [
+            "Infinity",
+            "-Infinity",
+            "NaN"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "singleDoubleWrapper": {
+      "$ref": "google.protobuf.DoubleValue.jsonschema.json"
+    },
+    "singleDuration": {
+      "$ref": "google.protobuf.Duration.jsonschema.json"
+    },
+    "singleFixed32": {
+      "maximum": 4294967295,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "singleFixed64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 18446744073709551616,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "singleFloat": {
+      "anyOf": [
+        {
+          "maximum": 3.4028234663852886e+38,
+          "minimum": -3.4028234663852886e+38,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "Infinity",
+            "-Infinity",
+            "NaN"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "singleFloatWrapper": {
+      "$ref": "google.protobuf.FloatValue.jsonschema.json"
+    },
+    "singleInt32": {
+      "description": "Singular",
+      "maximum": 2147483647,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "singleInt32Wrapper": {
+      "$ref": "google.protobuf.Int32Value.jsonschema.json"
+    },
+    "singleInt64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "singleInt64Wrapper": {
+      "$ref": "google.protobuf.Int64Value.jsonschema.json"
+    },
+    "singleNestedEnum": {
+      "anyOf": [
+        {
+          "enum": [
+            "FOO",
+            "BAR",
+            "BAZ"
+          ],
+          "title": "Nested Enum",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "singleNestedMessage": {
+      "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+    },
+    "singleSfixed32": {
+      "maximum": 2147483647,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "singleSfixed64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "singleSint32": {
+      "maximum": 2147483647,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "singleSint64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "singleString": {
+      "type": "string"
+    },
+    "singleStringWrapper": {
+      "$ref": "google.protobuf.StringValue.jsonschema.json"
+    },
+    "singleStruct": {
+      "$ref": "google.protobuf.Struct.jsonschema.json"
+    },
+    "singleTimestamp": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "singleUint32": {
+      "maximum": 4294967295,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "singleUint32Wrapper": {
+      "$ref": "google.protobuf.UInt32Value.jsonschema.json"
+    },
+    "singleUint64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 18446744073709551616,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "singleUint64Wrapper": {
+      "$ref": "google.protobuf.UInt64Value.jsonschema.json"
+    },
+    "singleValue": {
+      "$ref": "google.protobuf.Value.jsonschema.json"
+    },
+    "standaloneEnum": {
+      "anyOf": [
+        {
+          "enum": [
+            "FOO",
+            "BAR",
+            "BAZ"
+          ],
+          "title": "Nested Enum",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "standaloneMessage": {
+      "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
+    }
+  },
+  "title": "Test All Types",
+  "type": "object"
+}

--- a/internal/gen/jsonschema/bufext.cel.expr.conformance.proto3.TestAllTypes.schema.json
+++ b/internal/gen/jsonschema/bufext.cel.expr.conformance.proto3.TestAllTypes.schema.json
@@ -1,0 +1,6482 @@
+{
+  "$id": "bufext.cel.expr.conformance.proto3.TestAllTypes.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "description": "This proto includes every type of field in both singular and repeated\n forms.",
+  "patternProperties": {
+    "^(listValue)$": {
+      "$ref": "google.protobuf.ListValue.schema.json"
+    },
+    "^(mapBoolAny)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Any.schema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(mapBoolBool)$": {
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(mapBoolBoolWrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BoolValue.schema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(mapBoolBytes)$": {
+      "additionalProperties": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(mapBoolBytesWrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BytesValue.schema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(mapBoolDouble)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(mapBoolDoubleWrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.DoubleValue.schema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(mapBoolDuration)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Duration.schema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(mapBoolEnum)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(mapBoolFloat)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "maximum": 3.4028234663852886e+38,
+            "minimum": -3.4028234663852886e+38,
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(mapBoolFloatWrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.FloatValue.schema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(mapBoolInt32)$": {
+      "additionalProperties": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(mapBoolInt32Wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int32Value.schema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(mapBoolInt64)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(mapBoolInt64Wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int64Value.schema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(mapBoolListValue)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.ListValue.schema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(mapBoolMessage)$": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.schema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(mapBoolNullValue)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(mapBoolString)$": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(mapBoolStringWrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.StringValue.schema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(mapBoolStruct)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Struct.schema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(mapBoolTimestamp)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Timestamp.schema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(mapBoolUint32)$": {
+      "additionalProperties": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(mapBoolUint32Wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt32Value.schema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(mapBoolUint64)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(mapBoolUint64Wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt64Value.schema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(mapBoolValue)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Value.schema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "^(mapInt32Any)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Any.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapInt32Bool)$": {
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapInt32BoolWrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BoolValue.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapInt32Bytes)$": {
+      "additionalProperties": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapInt32BytesWrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BytesValue.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapInt32Double)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapInt32DoubleWrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.DoubleValue.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapInt32Duration)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Duration.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapInt32Enum)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapInt32Float)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "maximum": 3.4028234663852886e+38,
+            "minimum": -3.4028234663852886e+38,
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapInt32FloatWrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.FloatValue.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapInt32Int32)$": {
+      "additionalProperties": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapInt32Int32Wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int32Value.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapInt32Int64)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapInt32Int64Wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int64Value.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapInt32ListValue)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.ListValue.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapInt32Message)$": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapInt32NullValue)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapInt32String)$": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapInt32StringWrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.StringValue.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapInt32Struct)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Struct.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapInt32Timestamp)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Timestamp.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapInt32Uint32)$": {
+      "additionalProperties": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapInt32Uint32Wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt32Value.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapInt32Uint64)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapInt32Uint64Wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt64Value.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapInt32Value)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Value.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapInt64Any)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Any.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapInt64Bool)$": {
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapInt64BoolWrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BoolValue.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapInt64Bytes)$": {
+      "additionalProperties": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapInt64BytesWrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BytesValue.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapInt64Double)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapInt64DoubleWrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.DoubleValue.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapInt64Duration)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Duration.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapInt64Enum)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapInt64Float)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "maximum": 3.4028234663852886e+38,
+            "minimum": -3.4028234663852886e+38,
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapInt64FloatWrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.FloatValue.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapInt64Int32)$": {
+      "additionalProperties": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapInt64Int32Wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int32Value.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapInt64Int64)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapInt64Int64Wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int64Value.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapInt64ListValue)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.ListValue.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapInt64Message)$": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapInt64NestedType)$": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.NestedTestAllTypes.schema.json"
+      },
+      "description": "Map",
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapInt64NullValue)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapInt64String)$": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapInt64StringWrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.StringValue.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapInt64Struct)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Struct.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapInt64Timestamp)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Timestamp.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapInt64Uint32)$": {
+      "additionalProperties": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapInt64Uint32Wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt32Value.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapInt64Uint64)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapInt64Uint64Wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt64Value.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapInt64Value)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Value.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapStringAny)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Any.schema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(mapStringBool)$": {
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(mapStringBoolWrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BoolValue.schema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(mapStringBytes)$": {
+      "additionalProperties": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(mapStringBytesWrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BytesValue.schema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(mapStringDouble)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(mapStringDoubleWrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.DoubleValue.schema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(mapStringDuration)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Duration.schema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(mapStringEnum)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(mapStringFloat)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "maximum": 3.4028234663852886e+38,
+            "minimum": -3.4028234663852886e+38,
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(mapStringFloatWrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.FloatValue.schema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(mapStringInt32)$": {
+      "additionalProperties": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(mapStringInt32Wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int32Value.schema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(mapStringInt64)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(mapStringInt64Wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int64Value.schema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(mapStringListValue)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.ListValue.schema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(mapStringMessage)$": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.schema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(mapStringNullValue)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(mapStringString)$": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(mapStringStringWrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.StringValue.schema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(mapStringStruct)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Struct.schema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(mapStringTimestamp)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Timestamp.schema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(mapStringUint32)$": {
+      "additionalProperties": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(mapStringUint32Wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt32Value.schema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(mapStringUint64)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(mapStringUint64Wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt64Value.schema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(mapStringValue)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Value.schema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(mapUint32Any)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Any.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapUint32Bool)$": {
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapUint32BoolWrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BoolValue.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapUint32Bytes)$": {
+      "additionalProperties": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapUint32BytesWrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BytesValue.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapUint32Double)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapUint32DoubleWrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.DoubleValue.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapUint32Duration)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Duration.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapUint32Enum)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapUint32Float)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "maximum": 3.4028234663852886e+38,
+            "minimum": -3.4028234663852886e+38,
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapUint32FloatWrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.FloatValue.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapUint32Int32)$": {
+      "additionalProperties": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapUint32Int32Wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int32Value.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapUint32Int64)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapUint32Int64Wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int64Value.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapUint32ListValue)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.ListValue.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapUint32Message)$": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapUint32NullValue)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapUint32String)$": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapUint32StringWrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.StringValue.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapUint32Struct)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Struct.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapUint32Timestamp)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Timestamp.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapUint32Uint32)$": {
+      "additionalProperties": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapUint32Uint32Wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt32Value.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapUint32Uint64)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapUint32Uint64Wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt64Value.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapUint32Value)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Value.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "^(mapUint64Any)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Any.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapUint64Bool)$": {
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapUint64BoolWrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BoolValue.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapUint64Bytes)$": {
+      "additionalProperties": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapUint64BytesWrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BytesValue.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapUint64Double)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapUint64DoubleWrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.DoubleValue.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapUint64Duration)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Duration.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapUint64Enum)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapUint64Float)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "maximum": 3.4028234663852886e+38,
+            "minimum": -3.4028234663852886e+38,
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapUint64FloatWrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.FloatValue.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapUint64Int32)$": {
+      "additionalProperties": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapUint64Int32Wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int32Value.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapUint64Int64)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapUint64Int64Wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int64Value.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapUint64ListValue)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.ListValue.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapUint64Message)$": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapUint64NullValue)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapUint64String)$": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapUint64StringWrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.StringValue.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapUint64Struct)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Struct.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapUint64Timestamp)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Timestamp.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapUint64Uint32)$": {
+      "additionalProperties": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapUint64Uint32Wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt32Value.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapUint64Uint64)$": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapUint64Uint64Wrapper)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt64Value.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(mapUint64Value)$": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Value.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "^(nullValue)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "NULL_VALUE"
+          ],
+          "title": "Null Value",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "^(optionalNullValue)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "NULL_VALUE"
+          ],
+          "title": "Null Value",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "^(repeatedAny)$": {
+      "description": "Repeated wellknown.",
+      "items": {
+        "$ref": "google.protobuf.Any.schema.json"
+      },
+      "type": "array"
+    },
+    "^(repeatedBool)$": {
+      "items": {
+        "type": "boolean"
+      },
+      "type": "array"
+    },
+    "^(repeatedBoolWrapper)$": {
+      "items": {
+        "$ref": "google.protobuf.BoolValue.schema.json"
+      },
+      "type": "array"
+    },
+    "^(repeatedBytes)$": {
+      "items": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "^(repeatedBytesWrapper)$": {
+      "items": {
+        "$ref": "google.protobuf.BytesValue.schema.json"
+      },
+      "type": "array"
+    },
+    "^(repeatedCord)$": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "^(repeatedDouble)$": {
+      "items": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "^(repeatedDoubleWrapper)$": {
+      "items": {
+        "$ref": "google.protobuf.DoubleValue.schema.json"
+      },
+      "type": "array"
+    },
+    "^(repeatedDuration)$": {
+      "items": {
+        "$ref": "google.protobuf.Duration.schema.json"
+      },
+      "type": "array"
+    },
+    "^(repeatedFixed32)$": {
+      "items": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "^(repeatedFixed64)$": {
+      "items": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "^(repeatedFloat)$": {
+      "items": {
+        "anyOf": [
+          {
+            "maximum": 3.4028234663852886e+38,
+            "minimum": -3.4028234663852886e+38,
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "^(repeatedFloatWrapper)$": {
+      "items": {
+        "$ref": "google.protobuf.FloatValue.schema.json"
+      },
+      "type": "array"
+    },
+    "^(repeatedInt32)$": {
+      "description": "Repeated",
+      "items": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "^(repeatedInt32Wrapper)$": {
+      "items": {
+        "$ref": "google.protobuf.Int32Value.schema.json"
+      },
+      "type": "array"
+    },
+    "^(repeatedInt64)$": {
+      "items": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "^(repeatedInt64Wrapper)$": {
+      "items": {
+        "$ref": "google.protobuf.Int64Value.schema.json"
+      },
+      "type": "array"
+    },
+    "^(repeatedLazyMessage)$": {
+      "items": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.schema.json"
+      },
+      "type": "array"
+    },
+    "^(repeatedListValue)$": {
+      "items": {
+        "$ref": "google.protobuf.ListValue.schema.json"
+      },
+      "type": "array"
+    },
+    "^(repeatedNestedEnum)$": {
+      "items": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "^(repeatedNestedMessage)$": {
+      "description": "Repeated and nested",
+      "items": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.schema.json"
+      },
+      "type": "array"
+    },
+    "^(repeatedNullValue)$": {
+      "items": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "^(repeatedSfixed32)$": {
+      "items": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "^(repeatedSfixed64)$": {
+      "items": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "^(repeatedSint32)$": {
+      "items": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "^(repeatedSint64)$": {
+      "items": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "^(repeatedString)$": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "^(repeatedStringPiece)$": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "^(repeatedStringWrapper)$": {
+      "items": {
+        "$ref": "google.protobuf.StringValue.schema.json"
+      },
+      "type": "array"
+    },
+    "^(repeatedStruct)$": {
+      "items": {
+        "$ref": "google.protobuf.Struct.schema.json"
+      },
+      "type": "array"
+    },
+    "^(repeatedTimestamp)$": {
+      "items": {
+        "$ref": "google.protobuf.Timestamp.schema.json"
+      },
+      "type": "array"
+    },
+    "^(repeatedUint32)$": {
+      "items": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "^(repeatedUint32Wrapper)$": {
+      "items": {
+        "$ref": "google.protobuf.UInt32Value.schema.json"
+      },
+      "type": "array"
+    },
+    "^(repeatedUint64)$": {
+      "items": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "^(repeatedUint64Wrapper)$": {
+      "items": {
+        "$ref": "google.protobuf.UInt64Value.schema.json"
+      },
+      "type": "array"
+    },
+    "^(repeatedValue)$": {
+      "items": {
+        "$ref": "google.protobuf.Value.schema.json"
+      },
+      "type": "array"
+    },
+    "^(singleAny)$": {
+      "$ref": "google.protobuf.Any.schema.json",
+      "description": "Wellknown."
+    },
+    "^(singleBool)$": {
+      "type": "boolean"
+    },
+    "^(singleBoolWrapper)$": {
+      "$ref": "google.protobuf.BoolValue.schema.json"
+    },
+    "^(singleBytes)$": {
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "^(singleBytesWrapper)$": {
+      "$ref": "google.protobuf.BytesValue.schema.json"
+    },
+    "^(singleDouble)$": {
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "enum": [
+            "Infinity",
+            "-Infinity",
+            "NaN"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "^(singleDoubleWrapper)$": {
+      "$ref": "google.protobuf.DoubleValue.schema.json"
+    },
+    "^(singleDuration)$": {
+      "$ref": "google.protobuf.Duration.schema.json"
+    },
+    "^(singleFixed32)$": {
+      "maximum": 4294967295,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "^(singleFixed64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 18446744073709551616,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(singleFloat)$": {
+      "anyOf": [
+        {
+          "maximum": 3.4028234663852886e+38,
+          "minimum": -3.4028234663852886e+38,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "Infinity",
+            "-Infinity",
+            "NaN"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "^(singleFloatWrapper)$": {
+      "$ref": "google.protobuf.FloatValue.schema.json"
+    },
+    "^(singleInt32)$": {
+      "description": "Singular",
+      "maximum": 2147483647,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(singleInt32Wrapper)$": {
+      "$ref": "google.protobuf.Int32Value.schema.json"
+    },
+    "^(singleInt64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(singleInt64Wrapper)$": {
+      "$ref": "google.protobuf.Int64Value.schema.json"
+    },
+    "^(singleNestedEnum)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "FOO",
+            "BAR",
+            "BAZ"
+          ],
+          "title": "Nested Enum",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "^(singleNestedMessage)$": {
+      "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.schema.json"
+    },
+    "^(singleSfixed32)$": {
+      "maximum": 2147483647,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(singleSfixed64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(singleSint32)$": {
+      "maximum": 2147483647,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(singleSint64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(singleString)$": {
+      "type": "string"
+    },
+    "^(singleStringWrapper)$": {
+      "$ref": "google.protobuf.StringValue.schema.json"
+    },
+    "^(singleStruct)$": {
+      "$ref": "google.protobuf.Struct.schema.json"
+    },
+    "^(singleTimestamp)$": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "^(singleUint32)$": {
+      "maximum": 4294967295,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "^(singleUint32Wrapper)$": {
+      "$ref": "google.protobuf.UInt32Value.schema.json"
+    },
+    "^(singleUint64)$": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 18446744073709551616,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "^(singleUint64Wrapper)$": {
+      "$ref": "google.protobuf.UInt64Value.schema.json"
+    },
+    "^(singleValue)$": {
+      "$ref": "google.protobuf.Value.schema.json"
+    },
+    "^(standaloneEnum)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "FOO",
+            "BAR",
+            "BAZ"
+          ],
+          "title": "Nested Enum",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "^(standaloneMessage)$": {
+      "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.schema.json"
+    }
+  },
+  "properties": {
+    "list_value": {
+      "$ref": "google.protobuf.ListValue.schema.json"
+    },
+    "map_bool_any": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Any.schema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "map_bool_bool": {
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "map_bool_bool_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BoolValue.schema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "map_bool_bytes": {
+      "additionalProperties": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "map_bool_bytes_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BytesValue.schema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "map_bool_double": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "map_bool_double_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.DoubleValue.schema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "map_bool_duration": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Duration.schema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "map_bool_enum": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "map_bool_float": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "maximum": 3.4028234663852886e+38,
+            "minimum": -3.4028234663852886e+38,
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "map_bool_float_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.FloatValue.schema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "map_bool_int32": {
+      "additionalProperties": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "map_bool_int32_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int32Value.schema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "map_bool_int64": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "map_bool_int64_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int64Value.schema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "map_bool_list_value": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.ListValue.schema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "map_bool_message": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.schema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "map_bool_null_value": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "map_bool_string": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "map_bool_string_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.StringValue.schema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "map_bool_struct": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Struct.schema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "map_bool_timestamp": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Timestamp.schema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "map_bool_uint32": {
+      "additionalProperties": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "map_bool_uint32_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt32Value.schema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "map_bool_uint64": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "map_bool_uint64_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt64Value.schema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "map_bool_value": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Value.schema.json"
+      },
+      "propertyNames": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "map_int32_any": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Any.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_int32_bool": {
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_int32_bool_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BoolValue.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_int32_bytes": {
+      "additionalProperties": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_int32_bytes_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BytesValue.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_int32_double": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_int32_double_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.DoubleValue.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_int32_duration": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Duration.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_int32_enum": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_int32_float": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "maximum": 3.4028234663852886e+38,
+            "minimum": -3.4028234663852886e+38,
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_int32_float_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.FloatValue.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_int32_int32": {
+      "additionalProperties": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_int32_int32_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int32Value.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_int32_int64": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_int32_int64_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int64Value.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_int32_list_value": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.ListValue.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_int32_message": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_int32_null_value": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_int32_string": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_int32_string_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.StringValue.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_int32_struct": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Struct.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_int32_timestamp": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Timestamp.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_int32_uint32": {
+      "additionalProperties": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_int32_uint32_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt32Value.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_int32_uint64": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_int32_uint64_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt64Value.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_int32_value": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Value.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_int64_any": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Any.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_int64_bool": {
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_int64_bool_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BoolValue.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_int64_bytes": {
+      "additionalProperties": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_int64_bytes_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BytesValue.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_int64_double": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_int64_double_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.DoubleValue.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_int64_duration": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Duration.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_int64_enum": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_int64_float": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "maximum": 3.4028234663852886e+38,
+            "minimum": -3.4028234663852886e+38,
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_int64_float_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.FloatValue.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_int64_int32": {
+      "additionalProperties": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_int64_int32_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int32Value.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_int64_int64": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_int64_int64_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int64Value.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_int64_list_value": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.ListValue.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_int64_message": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_int64_nested_type": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.NestedTestAllTypes.schema.json"
+      },
+      "description": "Map",
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_int64_null_value": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_int64_string": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_int64_string_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.StringValue.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_int64_struct": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Struct.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_int64_timestamp": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Timestamp.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_int64_uint32": {
+      "additionalProperties": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_int64_uint32_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt32Value.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_int64_uint64": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_int64_uint64_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt64Value.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_int64_value": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Value.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_string_any": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Any.schema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "map_string_bool": {
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "map_string_bool_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BoolValue.schema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "map_string_bytes": {
+      "additionalProperties": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "map_string_bytes_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BytesValue.schema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "map_string_double": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "map_string_double_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.DoubleValue.schema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "map_string_duration": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Duration.schema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "map_string_enum": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "map_string_float": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "maximum": 3.4028234663852886e+38,
+            "minimum": -3.4028234663852886e+38,
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "map_string_float_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.FloatValue.schema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "map_string_int32": {
+      "additionalProperties": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "map_string_int32_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int32Value.schema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "map_string_int64": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "map_string_int64_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int64Value.schema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "map_string_list_value": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.ListValue.schema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "map_string_message": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.schema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "map_string_null_value": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "map_string_string": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "map_string_string_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.StringValue.schema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "map_string_struct": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Struct.schema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "map_string_timestamp": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Timestamp.schema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "map_string_uint32": {
+      "additionalProperties": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "map_string_uint32_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt32Value.schema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "map_string_uint64": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "map_string_uint64_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt64Value.schema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "map_string_value": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Value.schema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "map_uint32_any": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Any.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_uint32_bool": {
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_uint32_bool_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BoolValue.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_uint32_bytes": {
+      "additionalProperties": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_uint32_bytes_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BytesValue.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_uint32_double": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_uint32_double_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.DoubleValue.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_uint32_duration": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Duration.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_uint32_enum": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_uint32_float": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "maximum": 3.4028234663852886e+38,
+            "minimum": -3.4028234663852886e+38,
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_uint32_float_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.FloatValue.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_uint32_int32": {
+      "additionalProperties": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_uint32_int32_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int32Value.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_uint32_int64": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_uint32_int64_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int64Value.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_uint32_list_value": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.ListValue.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_uint32_message": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_uint32_null_value": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_uint32_string": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_uint32_string_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.StringValue.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_uint32_struct": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Struct.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_uint32_timestamp": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Timestamp.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_uint32_uint32": {
+      "additionalProperties": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_uint32_uint32_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt32Value.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_uint32_uint64": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_uint32_uint64_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt64Value.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_uint32_value": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Value.schema.json"
+      },
+      "propertyNames": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "map_uint64_any": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Any.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_uint64_bool": {
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_uint64_bool_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BoolValue.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_uint64_bytes": {
+      "additionalProperties": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_uint64_bytes_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.BytesValue.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_uint64_double": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_uint64_double_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.DoubleValue.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_uint64_duration": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Duration.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_uint64_enum": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_uint64_float": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "maximum": 3.4028234663852886e+38,
+            "minimum": -3.4028234663852886e+38,
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_uint64_float_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.FloatValue.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_uint64_int32": {
+      "additionalProperties": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_uint64_int32_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int32Value.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_uint64_int64": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_uint64_int64_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Int64Value.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_uint64_list_value": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.ListValue.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_uint64_message": {
+      "additionalProperties": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_uint64_null_value": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_uint64_string": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_uint64_string_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.StringValue.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_uint64_struct": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Struct.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_uint64_timestamp": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Timestamp.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_uint64_uint32": {
+      "additionalProperties": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_uint64_uint32_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt32Value.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_uint64_uint64": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_uint64_uint64_wrapper": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.UInt64Value.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "map_uint64_value": {
+      "additionalProperties": {
+        "$ref": "google.protobuf.Value.schema.json"
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "null_value": {
+      "anyOf": [
+        {
+          "enum": [
+            "NULL_VALUE"
+          ],
+          "title": "Null Value",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "optional_null_value": {
+      "anyOf": [
+        {
+          "enum": [
+            "NULL_VALUE"
+          ],
+          "title": "Null Value",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "repeated_any": {
+      "description": "Repeated wellknown.",
+      "items": {
+        "$ref": "google.protobuf.Any.schema.json"
+      },
+      "type": "array"
+    },
+    "repeated_bool": {
+      "items": {
+        "type": "boolean"
+      },
+      "type": "array"
+    },
+    "repeated_bool_wrapper": {
+      "items": {
+        "$ref": "google.protobuf.BoolValue.schema.json"
+      },
+      "type": "array"
+    },
+    "repeated_bytes": {
+      "items": {
+        "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "repeated_bytes_wrapper": {
+      "items": {
+        "$ref": "google.protobuf.BytesValue.schema.json"
+      },
+      "type": "array"
+    },
+    "repeated_cord": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "repeated_double": {
+      "items": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "repeated_double_wrapper": {
+      "items": {
+        "$ref": "google.protobuf.DoubleValue.schema.json"
+      },
+      "type": "array"
+    },
+    "repeated_duration": {
+      "items": {
+        "$ref": "google.protobuf.Duration.schema.json"
+      },
+      "type": "array"
+    },
+    "repeated_fixed32": {
+      "items": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "repeated_fixed64": {
+      "items": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "repeated_float": {
+      "items": {
+        "anyOf": [
+          {
+            "maximum": 3.4028234663852886e+38,
+            "minimum": -3.4028234663852886e+38,
+            "type": "number"
+          },
+          {
+            "enum": [
+              "Infinity",
+              "-Infinity",
+              "NaN"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "repeated_float_wrapper": {
+      "items": {
+        "$ref": "google.protobuf.FloatValue.schema.json"
+      },
+      "type": "array"
+    },
+    "repeated_int32": {
+      "description": "Repeated",
+      "items": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "repeated_int32_wrapper": {
+      "items": {
+        "$ref": "google.protobuf.Int32Value.schema.json"
+      },
+      "type": "array"
+    },
+    "repeated_int64": {
+      "items": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "repeated_int64_wrapper": {
+      "items": {
+        "$ref": "google.protobuf.Int64Value.schema.json"
+      },
+      "type": "array"
+    },
+    "repeated_lazy_message": {
+      "items": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.schema.json"
+      },
+      "type": "array"
+    },
+    "repeated_list_value": {
+      "items": {
+        "$ref": "google.protobuf.ListValue.schema.json"
+      },
+      "type": "array"
+    },
+    "repeated_nested_enum": {
+      "items": {
+        "anyOf": [
+          {
+            "enum": [
+              "FOO",
+              "BAR",
+              "BAZ"
+            ],
+            "title": "Nested Enum",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "repeated_nested_message": {
+      "description": "Repeated and nested",
+      "items": {
+        "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.schema.json"
+      },
+      "type": "array"
+    },
+    "repeated_null_value": {
+      "items": {
+        "anyOf": [
+          {
+            "enum": [
+              "NULL_VALUE"
+            ],
+            "title": "Null Value",
+            "type": "string"
+          },
+          {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "integer"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "repeated_sfixed32": {
+      "items": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "repeated_sfixed64": {
+      "items": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "repeated_sint32": {
+      "items": {
+        "maximum": 2147483647,
+        "minimum": -2147483648,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "repeated_sint64": {
+      "items": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 9223372036854775808,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          {
+            "pattern": "^-?[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "repeated_string": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "repeated_string_piece": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "repeated_string_wrapper": {
+      "items": {
+        "$ref": "google.protobuf.StringValue.schema.json"
+      },
+      "type": "array"
+    },
+    "repeated_struct": {
+      "items": {
+        "$ref": "google.protobuf.Struct.schema.json"
+      },
+      "type": "array"
+    },
+    "repeated_timestamp": {
+      "items": {
+        "$ref": "google.protobuf.Timestamp.schema.json"
+      },
+      "type": "array"
+    },
+    "repeated_uint32": {
+      "items": {
+        "maximum": 4294967295,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "repeated_uint32_wrapper": {
+      "items": {
+        "$ref": "google.protobuf.UInt32Value.schema.json"
+      },
+      "type": "array"
+    },
+    "repeated_uint64": {
+      "items": {
+        "anyOf": [
+          {
+            "exclusiveMaximum": 18446744073709551616,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "type": "string"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "repeated_uint64_wrapper": {
+      "items": {
+        "$ref": "google.protobuf.UInt64Value.schema.json"
+      },
+      "type": "array"
+    },
+    "repeated_value": {
+      "items": {
+        "$ref": "google.protobuf.Value.schema.json"
+      },
+      "type": "array"
+    },
+    "single_any": {
+      "$ref": "google.protobuf.Any.schema.json",
+      "description": "Wellknown."
+    },
+    "single_bool": {
+      "type": "boolean"
+    },
+    "single_bool_wrapper": {
+      "$ref": "google.protobuf.BoolValue.schema.json"
+    },
+    "single_bytes": {
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "single_bytes_wrapper": {
+      "$ref": "google.protobuf.BytesValue.schema.json"
+    },
+    "single_double": {
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "enum": [
+            "Infinity",
+            "-Infinity",
+            "NaN"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "single_double_wrapper": {
+      "$ref": "google.protobuf.DoubleValue.schema.json"
+    },
+    "single_duration": {
+      "$ref": "google.protobuf.Duration.schema.json"
+    },
+    "single_fixed32": {
+      "maximum": 4294967295,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "single_fixed64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 18446744073709551616,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "single_float": {
+      "anyOf": [
+        {
+          "maximum": 3.4028234663852886e+38,
+          "minimum": -3.4028234663852886e+38,
+          "type": "number"
+        },
+        {
+          "enum": [
+            "Infinity",
+            "-Infinity",
+            "NaN"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "single_float_wrapper": {
+      "$ref": "google.protobuf.FloatValue.schema.json"
+    },
+    "single_int32": {
+      "description": "Singular",
+      "maximum": 2147483647,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "single_int32_wrapper": {
+      "$ref": "google.protobuf.Int32Value.schema.json"
+    },
+    "single_int64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "single_int64_wrapper": {
+      "$ref": "google.protobuf.Int64Value.schema.json"
+    },
+    "single_nested_enum": {
+      "anyOf": [
+        {
+          "enum": [
+            "FOO",
+            "BAR",
+            "BAZ"
+          ],
+          "title": "Nested Enum",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "single_nested_message": {
+      "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.schema.json"
+    },
+    "single_sfixed32": {
+      "maximum": 2147483647,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "single_sfixed64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "single_sint32": {
+      "maximum": 2147483647,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "single_sint64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 9223372036854775808,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        {
+          "pattern": "^-?[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "single_string": {
+      "type": "string"
+    },
+    "single_string_wrapper": {
+      "$ref": "google.protobuf.StringValue.schema.json"
+    },
+    "single_struct": {
+      "$ref": "google.protobuf.Struct.schema.json"
+    },
+    "single_timestamp": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "single_uint32": {
+      "maximum": 4294967295,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "single_uint32_wrapper": {
+      "$ref": "google.protobuf.UInt32Value.schema.json"
+    },
+    "single_uint64": {
+      "anyOf": [
+        {
+          "exclusiveMaximum": 18446744073709551616,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "single_uint64_wrapper": {
+      "$ref": "google.protobuf.UInt64Value.schema.json"
+    },
+    "single_value": {
+      "$ref": "google.protobuf.Value.schema.json"
+    },
+    "standalone_enum": {
+      "anyOf": [
+        {
+          "enum": [
+            "FOO",
+            "BAR",
+            "BAZ"
+          ],
+          "title": "Nested Enum",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "standalone_message": {
+      "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.schema.json"
+    }
+  },
+  "title": "Test All Types",
+  "type": "object"
+}

--- a/internal/gen/jsonschema/google.protobuf.Any.jsonschema.json
+++ b/internal/gen/jsonschema/google.protobuf.Any.jsonschema.json
@@ -1,0 +1,11 @@
+{
+  "$id": "google.protobuf.Any.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "@type": {
+      "type": "string"
+    }
+  },
+  "title": "Any",
+  "type": "object"
+}

--- a/internal/gen/jsonschema/google.protobuf.Any.schema.json
+++ b/internal/gen/jsonschema/google.protobuf.Any.schema.json
@@ -1,0 +1,11 @@
+{
+  "$id": "google.protobuf.Any.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "@type": {
+      "type": "string"
+    }
+  },
+  "title": "Any",
+  "type": "object"
+}

--- a/internal/gen/jsonschema/google.protobuf.BoolValue.jsonschema.json
+++ b/internal/gen/jsonschema/google.protobuf.BoolValue.jsonschema.json
@@ -1,0 +1,7 @@
+{
+  "$id": "google.protobuf.BoolValue.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The bool value.",
+  "title": "Bool Value",
+  "type": "boolean"
+}

--- a/internal/gen/jsonschema/google.protobuf.BoolValue.schema.json
+++ b/internal/gen/jsonschema/google.protobuf.BoolValue.schema.json
@@ -1,0 +1,7 @@
+{
+  "$id": "google.protobuf.BoolValue.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The bool value.",
+  "title": "Bool Value",
+  "type": "boolean"
+}

--- a/internal/gen/jsonschema/google.protobuf.BytesValue.jsonschema.json
+++ b/internal/gen/jsonschema/google.protobuf.BytesValue.jsonschema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "google.protobuf.BytesValue.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The bytes value.",
+  "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+  "title": "Bytes Value",
+  "type": "string"
+}

--- a/internal/gen/jsonschema/google.protobuf.BytesValue.schema.json
+++ b/internal/gen/jsonschema/google.protobuf.BytesValue.schema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "google.protobuf.BytesValue.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The bytes value.",
+  "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+  "title": "Bytes Value",
+  "type": "string"
+}

--- a/internal/gen/jsonschema/google.protobuf.DoubleValue.jsonschema.json
+++ b/internal/gen/jsonschema/google.protobuf.DoubleValue.jsonschema.json
@@ -1,0 +1,22 @@
+{
+  "$id": "google.protobuf.DoubleValue.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "anyOf": [
+    {
+      "type": "number"
+    },
+    {
+      "enum": [
+        "Infinity",
+        "-Infinity",
+        "NaN"
+      ],
+      "type": "string"
+    },
+    {
+      "type": "string"
+    }
+  ],
+  "description": "The double value.",
+  "title": "Double Value"
+}

--- a/internal/gen/jsonschema/google.protobuf.DoubleValue.schema.json
+++ b/internal/gen/jsonschema/google.protobuf.DoubleValue.schema.json
@@ -1,0 +1,22 @@
+{
+  "$id": "google.protobuf.DoubleValue.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "anyOf": [
+    {
+      "type": "number"
+    },
+    {
+      "enum": [
+        "Infinity",
+        "-Infinity",
+        "NaN"
+      ],
+      "type": "string"
+    },
+    {
+      "type": "string"
+    }
+  ],
+  "description": "The double value.",
+  "title": "Double Value"
+}

--- a/internal/gen/jsonschema/google.protobuf.Duration.jsonschema.json
+++ b/internal/gen/jsonschema/google.protobuf.Duration.jsonschema.json
@@ -1,0 +1,7 @@
+{
+  "$id": "google.protobuf.Duration.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "format": "duration",
+  "title": "Duration",
+  "type": "string"
+}

--- a/internal/gen/jsonschema/google.protobuf.Duration.schema.json
+++ b/internal/gen/jsonschema/google.protobuf.Duration.schema.json
@@ -1,0 +1,7 @@
+{
+  "$id": "google.protobuf.Duration.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "format": "duration",
+  "title": "Duration",
+  "type": "string"
+}

--- a/internal/gen/jsonschema/google.protobuf.FloatValue.jsonschema.json
+++ b/internal/gen/jsonschema/google.protobuf.FloatValue.jsonschema.json
@@ -1,0 +1,24 @@
+{
+  "$id": "google.protobuf.FloatValue.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "anyOf": [
+    {
+      "maximum": 3.4028234663852886e+38,
+      "minimum": -3.4028234663852886e+38,
+      "type": "number"
+    },
+    {
+      "enum": [
+        "Infinity",
+        "-Infinity",
+        "NaN"
+      ],
+      "type": "string"
+    },
+    {
+      "type": "string"
+    }
+  ],
+  "description": "The float value.",
+  "title": "Float Value"
+}

--- a/internal/gen/jsonschema/google.protobuf.FloatValue.schema.json
+++ b/internal/gen/jsonschema/google.protobuf.FloatValue.schema.json
@@ -1,0 +1,24 @@
+{
+  "$id": "google.protobuf.FloatValue.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "anyOf": [
+    {
+      "maximum": 3.4028234663852886e+38,
+      "minimum": -3.4028234663852886e+38,
+      "type": "number"
+    },
+    {
+      "enum": [
+        "Infinity",
+        "-Infinity",
+        "NaN"
+      ],
+      "type": "string"
+    },
+    {
+      "type": "string"
+    }
+  ],
+  "description": "The float value.",
+  "title": "Float Value"
+}

--- a/internal/gen/jsonschema/google.protobuf.Int32Value.jsonschema.json
+++ b/internal/gen/jsonschema/google.protobuf.Int32Value.jsonschema.json
@@ -1,0 +1,9 @@
+{
+  "$id": "google.protobuf.Int32Value.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The int32 value.",
+  "maximum": 2147483647,
+  "minimum": -2147483648,
+  "title": "Int32 Value",
+  "type": "integer"
+}

--- a/internal/gen/jsonschema/google.protobuf.Int32Value.schema.json
+++ b/internal/gen/jsonschema/google.protobuf.Int32Value.schema.json
@@ -1,0 +1,9 @@
+{
+  "$id": "google.protobuf.Int32Value.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The int32 value.",
+  "maximum": 2147483647,
+  "minimum": -2147483648,
+  "title": "Int32 Value",
+  "type": "integer"
+}

--- a/internal/gen/jsonschema/google.protobuf.Int64Value.jsonschema.json
+++ b/internal/gen/jsonschema/google.protobuf.Int64Value.jsonschema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "google.protobuf.Int64Value.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "anyOf": [
+    {
+      "exclusiveMaximum": 9223372036854775808,
+      "minimum": -9223372036854775808,
+      "type": "integer"
+    },
+    {
+      "pattern": "^-?[0-9]+$",
+      "type": "string"
+    }
+  ],
+  "description": "The int64 value.",
+  "title": "Int64 Value"
+}

--- a/internal/gen/jsonschema/google.protobuf.Int64Value.schema.json
+++ b/internal/gen/jsonschema/google.protobuf.Int64Value.schema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "google.protobuf.Int64Value.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "anyOf": [
+    {
+      "exclusiveMaximum": 9223372036854775808,
+      "minimum": -9223372036854775808,
+      "type": "integer"
+    },
+    {
+      "pattern": "^-?[0-9]+$",
+      "type": "string"
+    }
+  ],
+  "description": "The int64 value.",
+  "title": "Int64 Value"
+}

--- a/internal/gen/jsonschema/google.protobuf.ListValue.jsonschema.json
+++ b/internal/gen/jsonschema/google.protobuf.ListValue.jsonschema.json
@@ -1,0 +1,6 @@
+{
+  "$id": "google.protobuf.ListValue.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "List Value",
+  "type": "array"
+}

--- a/internal/gen/jsonschema/google.protobuf.ListValue.schema.json
+++ b/internal/gen/jsonschema/google.protobuf.ListValue.schema.json
@@ -1,0 +1,6 @@
+{
+  "$id": "google.protobuf.ListValue.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "List Value",
+  "type": "array"
+}

--- a/internal/gen/jsonschema/google.protobuf.StringValue.jsonschema.json
+++ b/internal/gen/jsonschema/google.protobuf.StringValue.jsonschema.json
@@ -1,0 +1,7 @@
+{
+  "$id": "google.protobuf.StringValue.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The string value.",
+  "title": "String Value",
+  "type": "string"
+}

--- a/internal/gen/jsonschema/google.protobuf.StringValue.schema.json
+++ b/internal/gen/jsonschema/google.protobuf.StringValue.schema.json
@@ -1,0 +1,7 @@
+{
+  "$id": "google.protobuf.StringValue.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The string value.",
+  "title": "String Value",
+  "type": "string"
+}

--- a/internal/gen/jsonschema/google.protobuf.Struct.jsonschema.json
+++ b/internal/gen/jsonschema/google.protobuf.Struct.jsonschema.json
@@ -1,0 +1,6 @@
+{
+  "$id": "google.protobuf.Struct.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Struct",
+  "type": "object"
+}

--- a/internal/gen/jsonschema/google.protobuf.Struct.schema.json
+++ b/internal/gen/jsonschema/google.protobuf.Struct.schema.json
@@ -1,0 +1,6 @@
+{
+  "$id": "google.protobuf.Struct.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Struct",
+  "type": "object"
+}

--- a/internal/gen/jsonschema/google.protobuf.Timestamp.jsonschema.json
+++ b/internal/gen/jsonschema/google.protobuf.Timestamp.jsonschema.json
@@ -1,0 +1,7 @@
+{
+  "$id": "google.protobuf.Timestamp.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "format": "date-time",
+  "title": "Timestamp",
+  "type": "string"
+}

--- a/internal/gen/jsonschema/google.protobuf.Timestamp.schema.json
+++ b/internal/gen/jsonschema/google.protobuf.Timestamp.schema.json
@@ -1,0 +1,7 @@
+{
+  "$id": "google.protobuf.Timestamp.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "format": "date-time",
+  "title": "Timestamp",
+  "type": "string"
+}

--- a/internal/gen/jsonschema/google.protobuf.UInt32Value.jsonschema.json
+++ b/internal/gen/jsonschema/google.protobuf.UInt32Value.jsonschema.json
@@ -1,0 +1,9 @@
+{
+  "$id": "google.protobuf.UInt32Value.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The uint32 value.",
+  "maximum": 4294967295,
+  "minimum": 0,
+  "title": "U Int32 Value",
+  "type": "integer"
+}

--- a/internal/gen/jsonschema/google.protobuf.UInt32Value.schema.json
+++ b/internal/gen/jsonschema/google.protobuf.UInt32Value.schema.json
@@ -1,0 +1,9 @@
+{
+  "$id": "google.protobuf.UInt32Value.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The uint32 value.",
+  "maximum": 4294967295,
+  "minimum": 0,
+  "title": "U Int32 Value",
+  "type": "integer"
+}

--- a/internal/gen/jsonschema/google.protobuf.UInt64Value.jsonschema.json
+++ b/internal/gen/jsonschema/google.protobuf.UInt64Value.jsonschema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "google.protobuf.UInt64Value.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "anyOf": [
+    {
+      "exclusiveMaximum": 18446744073709551616,
+      "minimum": 0,
+      "type": "integer"
+    },
+    {
+      "pattern": "^[0-9]+$",
+      "type": "string"
+    }
+  ],
+  "description": "The uint64 value.",
+  "title": "U Int64 Value"
+}

--- a/internal/gen/jsonschema/google.protobuf.UInt64Value.schema.json
+++ b/internal/gen/jsonschema/google.protobuf.UInt64Value.schema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "google.protobuf.UInt64Value.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "anyOf": [
+    {
+      "exclusiveMaximum": 18446744073709551616,
+      "minimum": 0,
+      "type": "integer"
+    },
+    {
+      "pattern": "^[0-9]+$",
+      "type": "string"
+    }
+  ],
+  "description": "The uint64 value.",
+  "title": "U Int64 Value"
+}

--- a/internal/gen/jsonschema/google.protobuf.Value.jsonschema.json
+++ b/internal/gen/jsonschema/google.protobuf.Value.jsonschema.json
@@ -1,0 +1,5 @@
+{
+  "$id": "google.protobuf.Value.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Value"
+}

--- a/internal/gen/jsonschema/google.protobuf.Value.schema.json
+++ b/internal/gen/jsonschema/google.protobuf.Value.schema.json
@@ -1,0 +1,5 @@
+{
+  "$id": "google.protobuf.Value.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Value"
+}

--- a/internal/protoschema/jsonschema/jsonschema.go
+++ b/internal/protoschema/jsonschema/jsonschema.go
@@ -60,6 +60,13 @@ func WithJSONNames() GeneratorOption {
 	}
 }
 
+// WithAdditionalProperties sets the generator to allow additional properties on messages.
+func WithAdditionalProperties() GeneratorOption {
+	return func(p *jsonSchemaGenerator) {
+		p.additionalProperties = true
+	}
+}
+
 // Generate generates a JSON schema for the given message descriptor, with protobuf field names.
 func Generate(input protoreflect.MessageDescriptor, opts ...GeneratorOption) map[protoreflect.FullName]map[string]any {
 	generator := &jsonSchemaGenerator{
@@ -74,9 +81,10 @@ func Generate(input protoreflect.MessageDescriptor, opts ...GeneratorOption) map
 }
 
 type jsonSchemaGenerator struct {
-	schema       map[protoreflect.FullName]map[string]any
-	custom       map[protoreflect.FullName]func(protoreflect.MessageDescriptor, *validate.FieldConstraints, map[string]any)
-	useJSONNames bool
+	schema               map[protoreflect.FullName]map[string]any
+	custom               map[protoreflect.FullName]func(protoreflect.MessageDescriptor, *validate.FieldConstraints, map[string]any)
+	useJSONNames         bool
+	additionalProperties bool
 }
 
 func (p *jsonSchemaGenerator) getID(desc protoreflect.Descriptor) string {
@@ -158,7 +166,7 @@ func (p *jsonSchemaGenerator) generateDefault(desc protoreflect.MessageDescripto
 		}
 	}
 	schema["properties"] = properties
-	schema["additionalProperties"] = false
+	schema["additionalProperties"] = p.additionalProperties
 	if len(patternProperties) > 0 {
 		schema["patternProperties"] = patternProperties
 	}


### PR DESCRIPTION
See https://github.com/bufbuild/protoschema-plugins/issues/66

This is useful when a client/sender may have a schema version that is newer than the server/receiver. For example, this happens when updating a cluster that uses a peer-to-peer protocol.