### PR TITLE
Set JSON schema's "default" property

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Results in the following JSON Schema files:
       "description": "The location of the product."
     }
   },
-  "required": ["product_id", "product_name", "location"]
+  "required": ["product_id", "product_name", "location"],
   "patternProperties": {
     "^(productId)$": {
       "description": "The unique identifier for the product.",
@@ -161,7 +161,7 @@ Results in the following JSON Schema files:
       "description": "The name of the product.",
       "type": "string"
     }
-  },
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Results in the following JSON Schema files:
       "type": "array"
     },
     "location": {
-      "$ref": "buf.protoschema.test.v1.Product.Location.schema.json",
+      "$ref": "Product.Location.schema.json",
       "description": "The location of the product."
     }
   },

--- a/README.md
+++ b/README.md
@@ -112,9 +112,15 @@ Results in the following JSON Schema files:
   "description": "A product is a good or service that is offered for sale.",
   "type": "object",
   "properties": {
-    "location": {
-      "$ref": "buf.protoschema.test.v1.Product.Location.schema.json",
-      "description": "The location of the product."
+    "product_id": {
+      "description": "The unique identifier for the product.",
+      "maximum": 2147483647,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "product_name": {
+      "description": "The name of the product.",
+      "type": "string"
     },
     "price": {
       "anyOf": [
@@ -131,22 +137,16 @@ Results in the following JSON Schema files:
       "default": 0,
       "description": "The price of the product."
     },
-    "product_id": {
-      "description": "The unique identifier for the product.",
-      "maximum": 2147483647,
-      "minimum": -2147483648,
-      "type": "integer"
-    },
-    "product_name": {
-      "description": "The name of the product.",
-      "type": "string"
-    },
     "tags": {
       "description": "The tags associated with the product.",
       "items": {
         "type": "string"
       },
       "type": "array"
+    },
+    "location": {
+      "$ref": "buf.protoschema.test.v1.Product.Location.schema.json",
+      "description": "The location of the product."
     }
   },
   "required": ["product_id", "product_name", "location"]

--- a/README.md
+++ b/README.md
@@ -111,44 +111,6 @@ Results in the following JSON Schema files:
   "title": "A product.",
   "description": "A product is a good or service that is offered for sale.",
   "type": "object",
-  "properties": {
-    "product_id": {
-      "description": "The unique identifier for the product.",
-      "maximum": 2147483647,
-      "minimum": -2147483648,
-      "type": "integer"
-    },
-    "product_name": {
-      "description": "The name of the product.",
-      "type": "string"
-    },
-    "price": {
-      "anyOf": [
-        {
-          "maximum": 3.4028234663852886e38,
-          "minimum": -3.4028234663852886e38,
-          "type": "number"
-        },
-        {
-          "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
-          "type": "string"
-        }
-      ],
-      "description": "The price of the product."
-    },
-    "tags": {
-      "description": "The tags associated with the product.",
-      "items": {
-        "type": "string"
-      },
-      "type": "array"
-    }
-    "location": {
-      "$ref": "Location.schema.json",
-      "description": "The location of the product."
-    },
-  },
-  "required": ["product_id", "product_name", "location"],
   "patternProperties": {
     "^(productId)$": {
       "description": "The unique identifier for the product.",
@@ -160,7 +122,46 @@ Results in the following JSON Schema files:
       "description": "The name of the product.",
       "type": "string"
     }
-  }
+  },
+  "properties": {
+    "location": {
+      "$ref": "buf.protoschema.test.v1.Product.Location.schema.json",
+      "description": "The location of the product."
+    },
+    "price": {
+      "anyOf": [
+        {
+          "maximum": 3.4028234663852886e38,
+          "minimum": 0,
+          "type": "number"
+        },
+        {
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
+          "type": "string"
+        }
+      ],
+      "default": 0,
+      "description": "The price of the product."
+    },
+    "product_id": {
+      "description": "The unique identifier for the product.",
+      "maximum": 2147483647,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "product_name": {
+      "description": "The name of the product.",
+      "type": "string"
+    },
+    "tags": {
+      "description": "The tags associated with the product.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    }
+  },
+  "required": ["product_id", "product_name", "location"]
 }
 ```
 
@@ -189,7 +190,8 @@ Results in the following JSON Schema files:
           "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "long": {
       "anyOf": [
@@ -202,7 +204,8 @@ Results in the following JSON Schema files:
           "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -111,18 +111,6 @@ Results in the following JSON Schema files:
   "title": "A product.",
   "description": "A product is a good or service that is offered for sale.",
   "type": "object",
-  "patternProperties": {
-    "^(productId)$": {
-      "description": "The unique identifier for the product.",
-      "maximum": 2147483647,
-      "minimum": -2147483648,
-      "type": "integer"
-    },
-    "^(productName)$": {
-      "description": "The name of the product.",
-      "type": "string"
-    }
-  },
   "properties": {
     "location": {
       "$ref": "buf.protoschema.test.v1.Product.Location.schema.json",
@@ -162,6 +150,18 @@ Results in the following JSON Schema files:
     }
   },
   "required": ["product_id", "product_name", "location"]
+  "patternProperties": {
+    "^(productId)$": {
+      "description": "The unique identifier for the product.",
+      "maximum": 2147483647,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(productName)$": {
+      "description": "The name of the product.",
+      "type": "string"
+    }
+  },
 }
 ```
 

--- a/internal/protoschema/jsonschema/jsonschema.go
+++ b/internal/protoschema/jsonschema/jsonschema.go
@@ -255,7 +255,7 @@ func (p *jsonSchemaGenerator) getFieldConstraints(field protoreflect.FieldDescri
 	return constraints
 }
 
-func (p *jsonSchemaGenerator) hasImplicitDefault(field protoreflect.FieldDescriptor, hasPresence bool, constraints *validate.FieldConstraints, schema map[string]any) bool {
+func (p *jsonSchemaGenerator) hasImplicitDefault(field protoreflect.FieldDescriptor, hasPresence bool, constraints *validate.FieldConstraints) bool {
 	if field.HasPresence() || hasPresence || field.IsList() {
 		return false // Default values is absence.
 	}
@@ -267,7 +267,7 @@ func (p *jsonSchemaGenerator) hasImplicitDefault(field protoreflect.FieldDescrip
 }
 
 func (p *jsonSchemaGenerator) generateDefault(field protoreflect.FieldDescriptor, hasImplicitPresence bool, constraints *validate.FieldConstraints, schema map[string]any) {
-	if p.hasImplicitDefault(field, hasImplicitPresence, constraints, schema) {
+	if p.hasImplicitDefault(field, hasImplicitPresence, constraints) {
 		// Explicitly define the implicit protobuf default value in the JSON schema.
 		schema["default"] = field.Default().Interface()
 	}

--- a/internal/protoschema/jsonschema/jsonschema_test.go
+++ b/internal/protoschema/jsonschema/jsonschema_test.go
@@ -51,14 +51,14 @@ func TestJSONSchemaGolden(t *testing.T) {
 
 func TestTitle(t *testing.T) {
 	t.Parallel()
-	require.Equal(t, "Foo", generateTitle("Foo"))
-	require.Equal(t, "Foo Bar", generateTitle("FooBar"))
-	require.Equal(t, "foo Bar", generateTitle("fooBar"))
-	require.Equal(t, "Foo Bar Baz", generateTitle("FooBarBaz"))
-	require.Equal(t, "FOO Bar", generateTitle("FOOBar"))
-	require.Equal(t, "U Int64 Value", generateTitle("UInt64Value"))
-	require.Equal(t, "Uint64 Value", generateTitle("Uint64Value"))
-	require.Equal(t, "FOO", generateTitle("FOO"))
+	require.Equal(t, "Foo", nameToTitle("Foo"))
+	require.Equal(t, "Foo Bar", nameToTitle("FooBar"))
+	require.Equal(t, "foo Bar", nameToTitle("fooBar"))
+	require.Equal(t, "Foo Bar Baz", nameToTitle("FooBarBaz"))
+	require.Equal(t, "FOO Bar", nameToTitle("FOOBar"))
+	require.Equal(t, "U Int64 Value", nameToTitle("UInt64Value"))
+	require.Equal(t, "Uint64 Value", nameToTitle("Uint64Value"))
+	require.Equal(t, "FOO", nameToTitle("FOO"))
 }
 
 func TestConstraints(t *testing.T) {

--- a/internal/testdata/jsonschema/buf.protoschema.test.v1.ConstraintTest.jsonschema.json
+++ b/internal/testdata/jsonschema/buf.protoschema.test.v1.ConstraintTest.jsonschema.json
@@ -25,7 +25,8 @@
           "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(const_enum)$": {
       "anyOf": [
@@ -58,7 +59,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(const_fixed64)$": {
       "anyOf": [
@@ -74,7 +76,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(const_float)$": {
       "anyOf": [
@@ -90,7 +93,8 @@
           "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(const_int32)$": {
       "anyOf": [
@@ -287,7 +291,8 @@
           "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(finite_float)$": {
       "anyOf": [
@@ -300,7 +305,8 @@
           "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(gt_double)$": {
       "anyOf": [
@@ -317,7 +323,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(gt_fixed32)$": {
       "anyOf": [
@@ -330,7 +337,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(gt_fixed64)$": {
       "anyOf": [
@@ -343,7 +351,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(gt_float)$": {
       "anyOf": [
@@ -361,7 +370,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(gt_int32)$": {
       "anyOf": [
@@ -482,7 +492,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(gte_fixed32)$": {
       "anyOf": [
@@ -495,7 +506,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(gte_fixed64)$": {
       "anyOf": [
@@ -508,7 +520,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(gte_float)$": {
       "anyOf": [
@@ -526,7 +539,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(gte_int32)$": {
       "anyOf": [
@@ -674,7 +688,8 @@
           "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(in_enum)$": {
       "anyOf": [
@@ -710,7 +725,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(in_fixed64)$": {
       "anyOf": [
@@ -727,7 +743,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(in_float)$": {
       "anyOf": [
@@ -744,7 +761,8 @@
           "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(in_int32)$": {
       "anyOf": [
@@ -968,7 +986,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(lt_fixed32)$": {
       "anyOf": [
@@ -981,7 +1000,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(lt_fixed64)$": {
       "anyOf": [
@@ -994,7 +1014,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(lt_float)$": {
       "anyOf": [
@@ -1012,7 +1033,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(lt_gt_double)$": {
       "anyOf": [
@@ -1034,7 +1056,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(lt_gt_float)$": {
       "anyOf": [
@@ -1056,7 +1079,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(lt_gt_int32)$": {
       "anyOf": [
@@ -1249,7 +1273,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(lte_fixed32)$": {
       "anyOf": [
@@ -1262,7 +1287,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(lte_fixed64)$": {
       "anyOf": [
@@ -1275,7 +1301,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(lte_float)$": {
       "anyOf": [
@@ -1293,7 +1320,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(lte_int32)$": {
       "anyOf": [
@@ -1511,7 +1539,8 @@
           "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "constEnum": {
       "anyOf": [
@@ -1544,7 +1573,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "constFixed64": {
       "anyOf": [
@@ -1560,7 +1590,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "constFloat": {
       "anyOf": [
@@ -1576,7 +1607,8 @@
           "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "constInt32": {
       "anyOf": [
@@ -1773,7 +1805,8 @@
           "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "finiteFloat": {
       "anyOf": [
@@ -1786,7 +1819,8 @@
           "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "gtDouble": {
       "anyOf": [
@@ -1803,7 +1837,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "gtFixed32": {
       "anyOf": [
@@ -1816,7 +1851,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "gtFixed64": {
       "anyOf": [
@@ -1829,7 +1865,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "gtFloat": {
       "anyOf": [
@@ -1847,7 +1884,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "gtInt32": {
       "anyOf": [
@@ -1968,7 +2006,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "gteFixed32": {
       "anyOf": [
@@ -1981,7 +2020,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "gteFixed64": {
       "anyOf": [
@@ -1994,7 +2034,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "gteFloat": {
       "anyOf": [
@@ -2012,7 +2053,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "gteInt32": {
       "anyOf": [
@@ -2160,7 +2202,8 @@
           "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "inEnum": {
       "anyOf": [
@@ -2196,7 +2239,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "inFixed64": {
       "anyOf": [
@@ -2213,7 +2257,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "inFloat": {
       "anyOf": [
@@ -2230,7 +2275,8 @@
           "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "inInt32": {
       "anyOf": [
@@ -2454,7 +2500,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "ltFixed32": {
       "anyOf": [
@@ -2467,7 +2514,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "ltFixed64": {
       "anyOf": [
@@ -2480,7 +2528,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "ltFloat": {
       "anyOf": [
@@ -2498,7 +2547,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "ltGtDouble": {
       "anyOf": [
@@ -2520,7 +2570,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "ltGtFloat": {
       "anyOf": [
@@ -2542,7 +2593,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "ltGtInt32": {
       "anyOf": [
@@ -2735,7 +2787,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "lteFixed32": {
       "anyOf": [
@@ -2748,7 +2801,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "lteFixed64": {
       "anyOf": [
@@ -2761,7 +2815,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "lteFloat": {
       "anyOf": [
@@ -2779,7 +2834,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "lteInt32": {
       "anyOf": [

--- a/internal/testdata/jsonschema/buf.protoschema.test.v1.ConstraintTest.schema.json
+++ b/internal/testdata/jsonschema/buf.protoschema.test.v1.ConstraintTest.schema.json
@@ -25,7 +25,8 @@
           "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(constEnum)$": {
       "anyOf": [
@@ -58,7 +59,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(constFixed64)$": {
       "anyOf": [
@@ -74,7 +76,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(constFloat)$": {
       "anyOf": [
@@ -90,7 +93,8 @@
           "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(constInt32)$": {
       "anyOf": [
@@ -287,7 +291,8 @@
           "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(finiteFloat)$": {
       "anyOf": [
@@ -300,7 +305,8 @@
           "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(gtDouble)$": {
       "anyOf": [
@@ -317,7 +323,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(gtFixed32)$": {
       "anyOf": [
@@ -330,7 +337,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(gtFixed64)$": {
       "anyOf": [
@@ -343,7 +351,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(gtFloat)$": {
       "anyOf": [
@@ -361,7 +370,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(gtInt32)$": {
       "anyOf": [
@@ -482,7 +492,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(gteFixed32)$": {
       "anyOf": [
@@ -495,7 +506,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(gteFixed64)$": {
       "anyOf": [
@@ -508,7 +520,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(gteFloat)$": {
       "anyOf": [
@@ -526,7 +539,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(gteInt32)$": {
       "anyOf": [
@@ -674,7 +688,8 @@
           "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(inEnum)$": {
       "anyOf": [
@@ -710,7 +725,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(inFixed64)$": {
       "anyOf": [
@@ -727,7 +743,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(inFloat)$": {
       "anyOf": [
@@ -744,7 +761,8 @@
           "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(inInt32)$": {
       "anyOf": [
@@ -968,7 +986,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(ltFixed32)$": {
       "anyOf": [
@@ -981,7 +1000,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(ltFixed64)$": {
       "anyOf": [
@@ -994,7 +1014,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(ltFloat)$": {
       "anyOf": [
@@ -1012,7 +1033,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(ltGtDouble)$": {
       "anyOf": [
@@ -1034,7 +1056,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(ltGtFloat)$": {
       "anyOf": [
@@ -1056,7 +1079,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(ltGtInt32)$": {
       "anyOf": [
@@ -1249,7 +1273,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(lteFixed32)$": {
       "anyOf": [
@@ -1262,7 +1287,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(lteFixed64)$": {
       "anyOf": [
@@ -1275,7 +1301,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(lteFloat)$": {
       "anyOf": [
@@ -1293,7 +1320,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(lteInt32)$": {
       "anyOf": [
@@ -1511,7 +1539,8 @@
           "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "const_enum": {
       "anyOf": [
@@ -1544,7 +1573,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "const_fixed64": {
       "anyOf": [
@@ -1560,7 +1590,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "const_float": {
       "anyOf": [
@@ -1576,7 +1607,8 @@
           "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "const_int32": {
       "anyOf": [
@@ -1773,7 +1805,8 @@
           "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "finite_float": {
       "anyOf": [
@@ -1786,7 +1819,8 @@
           "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "gt_double": {
       "anyOf": [
@@ -1803,7 +1837,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "gt_fixed32": {
       "anyOf": [
@@ -1816,7 +1851,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "gt_fixed64": {
       "anyOf": [
@@ -1829,7 +1865,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "gt_float": {
       "anyOf": [
@@ -1847,7 +1884,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "gt_int32": {
       "anyOf": [
@@ -1968,7 +2006,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "gte_fixed32": {
       "anyOf": [
@@ -1981,7 +2020,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "gte_fixed64": {
       "anyOf": [
@@ -1994,7 +2034,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "gte_float": {
       "anyOf": [
@@ -2012,7 +2053,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "gte_int32": {
       "anyOf": [
@@ -2160,7 +2202,8 @@
           "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "in_enum": {
       "anyOf": [
@@ -2196,7 +2239,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "in_fixed64": {
       "anyOf": [
@@ -2213,7 +2257,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "in_float": {
       "anyOf": [
@@ -2230,7 +2275,8 @@
           "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "in_int32": {
       "anyOf": [
@@ -2454,7 +2500,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "lt_fixed32": {
       "anyOf": [
@@ -2467,7 +2514,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "lt_fixed64": {
       "anyOf": [
@@ -2480,7 +2528,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "lt_float": {
       "anyOf": [
@@ -2498,7 +2547,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "lt_gt_double": {
       "anyOf": [
@@ -2520,7 +2570,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "lt_gt_float": {
       "anyOf": [
@@ -2542,7 +2593,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "lt_gt_int32": {
       "anyOf": [
@@ -2735,7 +2787,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "lte_fixed32": {
       "anyOf": [
@@ -2748,7 +2801,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "lte_fixed64": {
       "anyOf": [
@@ -2761,7 +2815,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "lte_float": {
       "anyOf": [
@@ -2779,7 +2834,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "lte_int32": {
       "anyOf": [

--- a/internal/testdata/jsonschema/buf.protoschema.test.v1.IgnoreField.jsonschema.json
+++ b/internal/testdata/jsonschema/buf.protoschema.test.v1.IgnoreField.jsonschema.json
@@ -4,9 +4,11 @@
   "additionalProperties": false,
   "patternProperties": {
     "^(bool_field)$": {
+      "default": false,
       "type": "boolean"
     },
     "^(bytes_field|bytesField)$": {
+      "default": null,
       "pattern": "^[A-Za-z0-9+/]*={0,2}$",
       "type": "string"
     },
@@ -17,6 +19,7 @@
   },
   "properties": {
     "boolField": {
+      "default": false,
       "type": "boolean"
     }
   },

--- a/internal/testdata/jsonschema/buf.protoschema.test.v1.IgnoreField.schema.json
+++ b/internal/testdata/jsonschema/buf.protoschema.test.v1.IgnoreField.schema.json
@@ -4,9 +4,11 @@
   "additionalProperties": false,
   "patternProperties": {
     "^(boolField)$": {
+      "default": false,
       "type": "boolean"
     },
     "^(bytes_field|bytesField)$": {
+      "default": null,
       "pattern": "^[A-Za-z0-9+/]*={0,2}$",
       "type": "string"
     },
@@ -17,6 +19,7 @@
   },
   "properties": {
     "bool_field": {
+      "default": false,
       "type": "boolean"
     }
   },

--- a/internal/testdata/jsonschema/buf.protoschema.test.v1.Product.Location.jsonschema.json
+++ b/internal/testdata/jsonschema/buf.protoschema.test.v1.Product.Location.jsonschema.json
@@ -15,7 +15,8 @@
           "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "long": {
       "anyOf": [
@@ -28,7 +29,8 @@
           "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     }
   },
   "title": "Location",

--- a/internal/testdata/jsonschema/buf.protoschema.test.v1.Product.Location.schema.json
+++ b/internal/testdata/jsonschema/buf.protoschema.test.v1.Product.Location.schema.json
@@ -15,7 +15,8 @@
           "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "long": {
       "anyOf": [
@@ -28,7 +29,8 @@
           "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     }
   },
   "title": "Location",

--- a/internal/testdata/jsonschema/buf.protoschema.test.v1.Product.jsonschema.json
+++ b/internal/testdata/jsonschema/buf.protoschema.test.v1.Product.jsonschema.json
@@ -32,6 +32,7 @@
           "type": "string"
         }
       ],
+      "default": 0,
       "description": "The price of the product."
     },
     "productId": {

--- a/internal/testdata/jsonschema/buf.protoschema.test.v1.Product.schema.json
+++ b/internal/testdata/jsonschema/buf.protoschema.test.v1.Product.schema.json
@@ -32,6 +32,7 @@
           "type": "string"
         }
       ],
+      "default": 0,
       "description": "The price of the product."
     },
     "product_id": {

--- a/internal/testdata/jsonschema/bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json
+++ b/internal/testdata/jsonschema/bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json
@@ -4,6 +4,7 @@
   "additionalProperties": false,
   "properties": {
     "bb": {
+      "default": 0,
       "description": "The field name \"b\" fails to compile in proto1 because it conflicts with\n a local variable named \"b\" in one of the generated methods.\n This file needs to compile in proto1 to test backwards-compatibility.",
       "maximum": 2147483647,
       "minimum": -2147483648,

--- a/internal/testdata/jsonschema/bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.schema.json
+++ b/internal/testdata/jsonschema/bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.schema.json
@@ -4,6 +4,7 @@
   "additionalProperties": false,
   "properties": {
     "bb": {
+      "default": 0,
       "description": "The field name \"b\" fails to compile in proto1 because it conflicts with\n a local variable named \"b\" in one of the generated methods.\n This file needs to compile in proto1 to test backwards-compatibility.",
       "maximum": 2147483647,
       "minimum": -2147483648,

--- a/internal/testdata/jsonschema/bufext.cel.expr.conformance.proto3.TestAllTypes.jsonschema.json
+++ b/internal/testdata/jsonschema/bufext.cel.expr.conformance.proto3.TestAllTypes.jsonschema.json
@@ -2657,7 +2657,8 @@
           "minimum": -2147483648,
           "type": "integer"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(optional_null_value)$": {
       "anyOf": [
@@ -3020,12 +3021,14 @@
       "description": "Wellknown."
     },
     "^(single_bool)$": {
+      "default": false,
       "type": "boolean"
     },
     "^(single_bool_wrapper)$": {
       "$ref": "google.protobuf.BoolValue.jsonschema.json"
     },
     "^(single_bytes)$": {
+      "default": null,
       "pattern": "^[A-Za-z0-9+/]*={0,2}$",
       "type": "string"
     },
@@ -3048,7 +3051,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(single_double_wrapper)$": {
       "$ref": "google.protobuf.DoubleValue.jsonschema.json"
@@ -3057,6 +3061,7 @@
       "$ref": "google.protobuf.Duration.jsonschema.json"
     },
     "^(single_fixed32)$": {
+      "default": 0,
       "maximum": 4294967295,
       "minimum": 0,
       "type": "integer"
@@ -3072,7 +3077,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(single_float)$": {
       "anyOf": [
@@ -3092,12 +3098,14 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(single_float_wrapper)$": {
       "$ref": "google.protobuf.FloatValue.jsonschema.json"
     },
     "^(single_int32)$": {
+      "default": 0,
       "description": "Singular",
       "maximum": 2147483647,
       "minimum": -2147483648,
@@ -3117,7 +3125,8 @@
           "pattern": "^-?[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(single_int64_wrapper)$": {
       "$ref": "google.protobuf.Int64Value.jsonschema.json"
@@ -3144,6 +3153,7 @@
       "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
     },
     "^(single_sfixed32)$": {
+      "default": 0,
       "maximum": 2147483647,
       "minimum": -2147483648,
       "type": "integer"
@@ -3159,9 +3169,11 @@
           "pattern": "^-?[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(single_sint32)$": {
+      "default": 0,
       "maximum": 2147483647,
       "minimum": -2147483648,
       "type": "integer"
@@ -3177,9 +3189,11 @@
           "pattern": "^-?[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(single_string)$": {
+      "default": "",
       "type": "string"
     },
     "^(single_string_wrapper)$": {
@@ -3192,6 +3206,7 @@
       "$ref": "google.protobuf.Timestamp.jsonschema.json"
     },
     "^(single_uint32)$": {
+      "default": 0,
       "maximum": 4294967295,
       "minimum": 0,
       "type": "integer"
@@ -3210,7 +3225,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(single_uint64_wrapper)$": {
       "$ref": "google.protobuf.UInt64Value.jsonschema.json"
@@ -3234,7 +3250,8 @@
           "minimum": -2147483648,
           "type": "integer"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(standalone_message)$": {
       "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
@@ -5894,7 +5911,8 @@
           "minimum": -2147483648,
           "type": "integer"
         }
-      ]
+      ],
+      "default": 0
     },
     "optionalNullValue": {
       "anyOf": [
@@ -6257,12 +6275,14 @@
       "description": "Wellknown."
     },
     "singleBool": {
+      "default": false,
       "type": "boolean"
     },
     "singleBoolWrapper": {
       "$ref": "google.protobuf.BoolValue.jsonschema.json"
     },
     "singleBytes": {
+      "default": null,
       "pattern": "^[A-Za-z0-9+/]*={0,2}$",
       "type": "string"
     },
@@ -6285,7 +6305,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "singleDoubleWrapper": {
       "$ref": "google.protobuf.DoubleValue.jsonschema.json"
@@ -6294,6 +6315,7 @@
       "$ref": "google.protobuf.Duration.jsonschema.json"
     },
     "singleFixed32": {
+      "default": 0,
       "maximum": 4294967295,
       "minimum": 0,
       "type": "integer"
@@ -6309,7 +6331,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "singleFloat": {
       "anyOf": [
@@ -6329,12 +6352,14 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "singleFloatWrapper": {
       "$ref": "google.protobuf.FloatValue.jsonschema.json"
     },
     "singleInt32": {
+      "default": 0,
       "description": "Singular",
       "maximum": 2147483647,
       "minimum": -2147483648,
@@ -6354,7 +6379,8 @@
           "pattern": "^-?[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "singleInt64Wrapper": {
       "$ref": "google.protobuf.Int64Value.jsonschema.json"
@@ -6381,6 +6407,7 @@
       "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
     },
     "singleSfixed32": {
+      "default": 0,
       "maximum": 2147483647,
       "minimum": -2147483648,
       "type": "integer"
@@ -6396,9 +6423,11 @@
           "pattern": "^-?[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "singleSint32": {
+      "default": 0,
       "maximum": 2147483647,
       "minimum": -2147483648,
       "type": "integer"
@@ -6414,9 +6443,11 @@
           "pattern": "^-?[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "singleString": {
+      "default": "",
       "type": "string"
     },
     "singleStringWrapper": {
@@ -6429,6 +6460,7 @@
       "$ref": "google.protobuf.Timestamp.jsonschema.json"
     },
     "singleUint32": {
+      "default": 0,
       "maximum": 4294967295,
       "minimum": 0,
       "type": "integer"
@@ -6447,7 +6479,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "singleUint64Wrapper": {
       "$ref": "google.protobuf.UInt64Value.jsonschema.json"
@@ -6471,7 +6504,8 @@
           "minimum": -2147483648,
           "type": "integer"
         }
-      ]
+      ],
+      "default": 0
     },
     "standaloneMessage": {
       "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"

--- a/internal/testdata/jsonschema/bufext.cel.expr.conformance.proto3.TestAllTypes.schema.json
+++ b/internal/testdata/jsonschema/bufext.cel.expr.conformance.proto3.TestAllTypes.schema.json
@@ -2657,7 +2657,8 @@
           "minimum": -2147483648,
           "type": "integer"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(optionalNullValue)$": {
       "anyOf": [
@@ -3020,12 +3021,14 @@
       "description": "Wellknown."
     },
     "^(singleBool)$": {
+      "default": false,
       "type": "boolean"
     },
     "^(singleBoolWrapper)$": {
       "$ref": "google.protobuf.BoolValue.schema.json"
     },
     "^(singleBytes)$": {
+      "default": null,
       "pattern": "^[A-Za-z0-9+/]*={0,2}$",
       "type": "string"
     },
@@ -3048,7 +3051,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(singleDoubleWrapper)$": {
       "$ref": "google.protobuf.DoubleValue.schema.json"
@@ -3057,6 +3061,7 @@
       "$ref": "google.protobuf.Duration.schema.json"
     },
     "^(singleFixed32)$": {
+      "default": 0,
       "maximum": 4294967295,
       "minimum": 0,
       "type": "integer"
@@ -3072,7 +3077,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(singleFloat)$": {
       "anyOf": [
@@ -3092,12 +3098,14 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(singleFloatWrapper)$": {
       "$ref": "google.protobuf.FloatValue.schema.json"
     },
     "^(singleInt32)$": {
+      "default": 0,
       "description": "Singular",
       "maximum": 2147483647,
       "minimum": -2147483648,
@@ -3117,7 +3125,8 @@
           "pattern": "^-?[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(singleInt64Wrapper)$": {
       "$ref": "google.protobuf.Int64Value.schema.json"
@@ -3144,6 +3153,7 @@
       "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.schema.json"
     },
     "^(singleSfixed32)$": {
+      "default": 0,
       "maximum": 2147483647,
       "minimum": -2147483648,
       "type": "integer"
@@ -3159,9 +3169,11 @@
           "pattern": "^-?[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(singleSint32)$": {
+      "default": 0,
       "maximum": 2147483647,
       "minimum": -2147483648,
       "type": "integer"
@@ -3177,9 +3189,11 @@
           "pattern": "^-?[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(singleString)$": {
+      "default": "",
       "type": "string"
     },
     "^(singleStringWrapper)$": {
@@ -3192,6 +3206,7 @@
       "$ref": "google.protobuf.Timestamp.schema.json"
     },
     "^(singleUint32)$": {
+      "default": 0,
       "maximum": 4294967295,
       "minimum": 0,
       "type": "integer"
@@ -3210,7 +3225,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(singleUint64Wrapper)$": {
       "$ref": "google.protobuf.UInt64Value.schema.json"
@@ -3234,7 +3250,8 @@
           "minimum": -2147483648,
           "type": "integer"
         }
-      ]
+      ],
+      "default": 0
     },
     "^(standaloneMessage)$": {
       "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.schema.json"
@@ -5894,7 +5911,8 @@
           "minimum": -2147483648,
           "type": "integer"
         }
-      ]
+      ],
+      "default": 0
     },
     "optional_null_value": {
       "anyOf": [
@@ -6257,12 +6275,14 @@
       "description": "Wellknown."
     },
     "single_bool": {
+      "default": false,
       "type": "boolean"
     },
     "single_bool_wrapper": {
       "$ref": "google.protobuf.BoolValue.schema.json"
     },
     "single_bytes": {
+      "default": null,
       "pattern": "^[A-Za-z0-9+/]*={0,2}$",
       "type": "string"
     },
@@ -6285,7 +6305,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "single_double_wrapper": {
       "$ref": "google.protobuf.DoubleValue.schema.json"
@@ -6294,6 +6315,7 @@
       "$ref": "google.protobuf.Duration.schema.json"
     },
     "single_fixed32": {
+      "default": 0,
       "maximum": 4294967295,
       "minimum": 0,
       "type": "integer"
@@ -6309,7 +6331,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "single_float": {
       "anyOf": [
@@ -6329,12 +6352,14 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "single_float_wrapper": {
       "$ref": "google.protobuf.FloatValue.schema.json"
     },
     "single_int32": {
+      "default": 0,
       "description": "Singular",
       "maximum": 2147483647,
       "minimum": -2147483648,
@@ -6354,7 +6379,8 @@
           "pattern": "^-?[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "single_int64_wrapper": {
       "$ref": "google.protobuf.Int64Value.schema.json"
@@ -6381,6 +6407,7 @@
       "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.schema.json"
     },
     "single_sfixed32": {
+      "default": 0,
       "maximum": 2147483647,
       "minimum": -2147483648,
       "type": "integer"
@@ -6396,9 +6423,11 @@
           "pattern": "^-?[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "single_sint32": {
+      "default": 0,
       "maximum": 2147483647,
       "minimum": -2147483648,
       "type": "integer"
@@ -6414,9 +6443,11 @@
           "pattern": "^-?[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "single_string": {
+      "default": "",
       "type": "string"
     },
     "single_string_wrapper": {
@@ -6429,6 +6460,7 @@
       "$ref": "google.protobuf.Timestamp.schema.json"
     },
     "single_uint32": {
+      "default": 0,
       "maximum": 4294967295,
       "minimum": 0,
       "type": "integer"
@@ -6447,7 +6479,8 @@
           "pattern": "^[0-9]+$",
           "type": "string"
         }
-      ]
+      ],
+      "default": 0
     },
     "single_uint64_wrapper": {
       "$ref": "google.protobuf.UInt64Value.schema.json"
@@ -6471,7 +6504,8 @@
           "minimum": -2147483648,
           "type": "integer"
         }
-      ]
+      ],
+      "default": 0
     },
     "standalone_message": {
       "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.schema.json"


### PR DESCRIPTION
Non-optional proto3 scalar fields have implicit defaults. This PR updates the JSON schema (which doesn't have implicit defaults) to document these defaults.
Note that 'default' in JSON schema does not change the payload and is more for documentation (like examples).