### PR TITLE
Only emit 'interoperable' integers as defined in rfc8259

### DIFF
--- a/internal/gen/jsonschema/buf.protoschema.test.v1.ConstraintTest.jsonschema.json
+++ b/internal/gen/jsonschema/buf.protoschema.test.v1.ConstraintTest.jsonschema.json
@@ -48,7 +48,6 @@
       "enum": [
         5
       ],
-      "exclusiveMaximum": 18446744073709552000,
       "minimum": 0,
       "type": "integer"
     },
@@ -72,8 +71,6 @@
       "enum": [
         5
       ],
-      "exclusiveMaximum": 9223372036854775808,
-      "minimum": -9223372036854775808,
       "type": "integer"
     },
     "constSfixed32": {
@@ -88,8 +85,6 @@
       "enum": [
         5
       ],
-      "exclusiveMaximum": 9223372036854775808,
-      "minimum": -9223372036854775808,
       "type": "integer"
     },
     "constSint32": {
@@ -104,8 +99,6 @@
       "enum": [
         5
       ],
-      "exclusiveMaximum": 9223372036854775808,
-      "minimum": -9223372036854775808,
       "type": "integer"
     },
     "constString": {
@@ -126,7 +119,6 @@
       "enum": [
         5
       ],
-      "exclusiveMaximum": 18446744073709552000,
       "minimum": 0,
       "type": "integer"
     },
@@ -210,7 +202,6 @@
       "type": "integer"
     },
     "gtFixed64": {
-      "exclusiveMaximum": 18446744073709552000,
       "exclusiveMinimum": 5,
       "type": "integer"
     },
@@ -235,7 +226,6 @@
       "type": "integer"
     },
     "gtInt64": {
-      "exclusiveMaximum": 9223372036854775808,
       "exclusiveMinimum": 5,
       "type": "integer"
     },
@@ -245,7 +235,6 @@
       "type": "integer"
     },
     "gtSfixed64": {
-      "exclusiveMaximum": 9223372036854775808,
       "exclusiveMinimum": 5,
       "type": "integer"
     },
@@ -255,7 +244,6 @@
       "type": "integer"
     },
     "gtSint64": {
-      "exclusiveMaximum": 9223372036854775808,
       "exclusiveMinimum": 5,
       "type": "integer"
     },
@@ -265,7 +253,6 @@
       "type": "integer"
     },
     "gtUint64": {
-      "exclusiveMaximum": 18446744073709552000,
       "exclusiveMinimum": 5,
       "type": "integer"
     },
@@ -289,7 +276,6 @@
       "type": "integer"
     },
     "gteFixed64": {
-      "exclusiveMaximum": 18446744073709552000,
       "minimum": 5,
       "type": "integer"
     },
@@ -314,7 +300,6 @@
       "type": "integer"
     },
     "gteInt64": {
-      "exclusiveMaximum": 9223372036854775808,
       "minimum": 5,
       "type": "integer"
     },
@@ -324,7 +309,6 @@
       "type": "integer"
     },
     "gteSfixed64": {
-      "exclusiveMaximum": 9223372036854775808,
       "minimum": 5,
       "type": "integer"
     },
@@ -334,7 +318,6 @@
       "type": "integer"
     },
     "gteSint64": {
-      "exclusiveMaximum": 9223372036854775808,
       "minimum": 5,
       "type": "integer"
     },
@@ -344,7 +327,6 @@
       "type": "integer"
     },
     "gteUint64": {
-      "exclusiveMaximum": 18446744073709552000,
       "minimum": 5,
       "type": "integer"
     },
@@ -417,7 +399,6 @@
         1,
         2
       ],
-      "exclusiveMaximum": 18446744073709552000,
       "minimum": 0,
       "type": "integer"
     },
@@ -444,8 +425,6 @@
         1,
         2
       ],
-      "exclusiveMaximum": 9223372036854775808,
-      "minimum": -9223372036854775808,
       "type": "integer"
     },
     "inMap": {
@@ -479,8 +458,6 @@
         1,
         2
       ],
-      "exclusiveMaximum": 9223372036854775808,
-      "minimum": -9223372036854775808,
       "type": "integer"
     },
     "inSint32": {
@@ -497,8 +474,6 @@
         1,
         2
       ],
-      "exclusiveMaximum": 9223372036854775808,
-      "minimum": -9223372036854775808,
       "type": "integer"
     },
     "inString": {
@@ -522,7 +497,6 @@
         1,
         2
       ],
-      "exclusiveMaximum": 18446744073709552000,
       "minimum": 0,
       "type": "integer"
     },
@@ -668,11 +642,9 @@
       "anyOf": [
         {
           "exclusiveMaximum": 1,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
-          "exclusiveMaximum": 9223372036854775808,
           "exclusiveMinimum": 5,
           "type": "integer"
         }
@@ -700,7 +672,6 @@
           "type": "integer"
         },
         {
-          "exclusiveMaximum": 18446744073709552000,
           "exclusiveMinimum": 5,
           "type": "integer"
         }
@@ -713,7 +684,6 @@
     },
     "ltInt64": {
       "exclusiveMaximum": 5,
-      "minimum": -9223372036854775808,
       "type": "integer"
     },
     "ltSfixed32": {
@@ -723,7 +693,6 @@
     },
     "ltSfixed64": {
       "exclusiveMaximum": 5,
-      "minimum": -9223372036854775808,
       "type": "integer"
     },
     "ltSint32": {
@@ -733,7 +702,6 @@
     },
     "ltSint64": {
       "exclusiveMaximum": 5,
-      "minimum": -9223372036854775808,
       "type": "integer"
     },
     "ltUint32": {
@@ -792,7 +760,6 @@
     },
     "lteInt64": {
       "maximum": 5,
-      "minimum": -9223372036854775808,
       "type": "integer"
     },
     "lteSfixed32": {
@@ -802,7 +769,6 @@
     },
     "lteSfixed64": {
       "maximum": 5,
-      "minimum": -9223372036854775808,
       "type": "integer"
     },
     "lteSint32": {
@@ -812,7 +778,6 @@
     },
     "lteSint64": {
       "maximum": 5,
-      "minimum": -9223372036854775808,
       "type": "integer"
     },
     "lteUint32": {

--- a/internal/gen/jsonschema/buf.protoschema.test.v1.ConstraintTest.schema.json
+++ b/internal/gen/jsonschema/buf.protoschema.test.v1.ConstraintTest.schema.json
@@ -48,7 +48,6 @@
       "enum": [
         5
       ],
-      "exclusiveMaximum": 18446744073709552000,
       "minimum": 0,
       "type": "integer"
     },
@@ -72,8 +71,6 @@
       "enum": [
         5
       ],
-      "exclusiveMaximum": 9223372036854775808,
-      "minimum": -9223372036854775808,
       "type": "integer"
     },
     "const_sfixed32": {
@@ -88,8 +85,6 @@
       "enum": [
         5
       ],
-      "exclusiveMaximum": 9223372036854775808,
-      "minimum": -9223372036854775808,
       "type": "integer"
     },
     "const_sint32": {
@@ -104,8 +99,6 @@
       "enum": [
         5
       ],
-      "exclusiveMaximum": 9223372036854775808,
-      "minimum": -9223372036854775808,
       "type": "integer"
     },
     "const_string": {
@@ -126,7 +119,6 @@
       "enum": [
         5
       ],
-      "exclusiveMaximum": 18446744073709552000,
       "minimum": 0,
       "type": "integer"
     },
@@ -210,7 +202,6 @@
       "type": "integer"
     },
     "gt_fixed64": {
-      "exclusiveMaximum": 18446744073709552000,
       "exclusiveMinimum": 5,
       "type": "integer"
     },
@@ -235,7 +226,6 @@
       "type": "integer"
     },
     "gt_int64": {
-      "exclusiveMaximum": 9223372036854775808,
       "exclusiveMinimum": 5,
       "type": "integer"
     },
@@ -245,7 +235,6 @@
       "type": "integer"
     },
     "gt_sfixed64": {
-      "exclusiveMaximum": 9223372036854775808,
       "exclusiveMinimum": 5,
       "type": "integer"
     },
@@ -255,7 +244,6 @@
       "type": "integer"
     },
     "gt_sint64": {
-      "exclusiveMaximum": 9223372036854775808,
       "exclusiveMinimum": 5,
       "type": "integer"
     },
@@ -265,7 +253,6 @@
       "type": "integer"
     },
     "gt_uint64": {
-      "exclusiveMaximum": 18446744073709552000,
       "exclusiveMinimum": 5,
       "type": "integer"
     },
@@ -289,7 +276,6 @@
       "type": "integer"
     },
     "gte_fixed64": {
-      "exclusiveMaximum": 18446744073709552000,
       "minimum": 5,
       "type": "integer"
     },
@@ -314,7 +300,6 @@
       "type": "integer"
     },
     "gte_int64": {
-      "exclusiveMaximum": 9223372036854775808,
       "minimum": 5,
       "type": "integer"
     },
@@ -324,7 +309,6 @@
       "type": "integer"
     },
     "gte_sfixed64": {
-      "exclusiveMaximum": 9223372036854775808,
       "minimum": 5,
       "type": "integer"
     },
@@ -334,7 +318,6 @@
       "type": "integer"
     },
     "gte_sint64": {
-      "exclusiveMaximum": 9223372036854775808,
       "minimum": 5,
       "type": "integer"
     },
@@ -344,7 +327,6 @@
       "type": "integer"
     },
     "gte_uint64": {
-      "exclusiveMaximum": 18446744073709552000,
       "minimum": 5,
       "type": "integer"
     },
@@ -417,7 +399,6 @@
         1,
         2
       ],
-      "exclusiveMaximum": 18446744073709552000,
       "minimum": 0,
       "type": "integer"
     },
@@ -444,8 +425,6 @@
         1,
         2
       ],
-      "exclusiveMaximum": 9223372036854775808,
-      "minimum": -9223372036854775808,
       "type": "integer"
     },
     "in_map": {
@@ -479,8 +458,6 @@
         1,
         2
       ],
-      "exclusiveMaximum": 9223372036854775808,
-      "minimum": -9223372036854775808,
       "type": "integer"
     },
     "in_sint32": {
@@ -497,8 +474,6 @@
         1,
         2
       ],
-      "exclusiveMaximum": 9223372036854775808,
-      "minimum": -9223372036854775808,
       "type": "integer"
     },
     "in_string": {
@@ -522,7 +497,6 @@
         1,
         2
       ],
-      "exclusiveMaximum": 18446744073709552000,
       "minimum": 0,
       "type": "integer"
     },
@@ -668,11 +642,9 @@
       "anyOf": [
         {
           "exclusiveMaximum": 1,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
-          "exclusiveMaximum": 9223372036854775808,
           "exclusiveMinimum": 5,
           "type": "integer"
         }
@@ -700,7 +672,6 @@
           "type": "integer"
         },
         {
-          "exclusiveMaximum": 18446744073709552000,
           "exclusiveMinimum": 5,
           "type": "integer"
         }
@@ -713,7 +684,6 @@
     },
     "lt_int64": {
       "exclusiveMaximum": 5,
-      "minimum": -9223372036854775808,
       "type": "integer"
     },
     "lt_sfixed32": {
@@ -723,7 +693,6 @@
     },
     "lt_sfixed64": {
       "exclusiveMaximum": 5,
-      "minimum": -9223372036854775808,
       "type": "integer"
     },
     "lt_sint32": {
@@ -733,7 +702,6 @@
     },
     "lt_sint64": {
       "exclusiveMaximum": 5,
-      "minimum": -9223372036854775808,
       "type": "integer"
     },
     "lt_uint32": {
@@ -792,7 +760,6 @@
     },
     "lte_int64": {
       "maximum": 5,
-      "minimum": -9223372036854775808,
       "type": "integer"
     },
     "lte_sfixed32": {
@@ -802,7 +769,6 @@
     },
     "lte_sfixed64": {
       "maximum": 5,
-      "minimum": -9223372036854775808,
       "type": "integer"
     },
     "lte_sint32": {
@@ -812,7 +778,6 @@
     },
     "lte_sint64": {
       "maximum": 5,
-      "minimum": -9223372036854775808,
       "type": "integer"
     },
     "lte_uint32": {

--- a/internal/gen/jsonschema/bufext.cel.expr.conformance.proto3.TestAllTypes.jsonschema.json
+++ b/internal/gen/jsonschema/bufext.cel.expr.conformance.proto3.TestAllTypes.jsonschema.json
@@ -170,8 +170,6 @@
     },
     "mapBoolInt64": {
       "additionalProperties": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "propertyNames": {
@@ -286,7 +284,6 @@
     },
     "mapBoolUint64": {
       "additionalProperties": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -502,8 +499,6 @@
     },
     "mapInt32Int64": {
       "additionalProperties": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "propertyNames": {
@@ -640,7 +635,6 @@
     },
     "mapInt32Uint64": {
       "additionalProperties": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -678,8 +672,6 @@
         "$ref": "google.protobuf.Any.jsonschema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -689,8 +681,6 @@
         "type": "boolean"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -700,8 +690,6 @@
         "$ref": "google.protobuf.BoolValue.jsonschema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -712,8 +700,6 @@
         "type": "string"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -723,8 +709,6 @@
         "$ref": "google.protobuf.BytesValue.jsonschema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -746,8 +730,6 @@
         ]
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -757,8 +739,6 @@
         "$ref": "google.protobuf.DoubleValue.jsonschema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -768,8 +748,6 @@
         "$ref": "google.protobuf.Duration.jsonschema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -794,8 +772,6 @@
         "title": "Nested Enum"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -819,8 +795,6 @@
         ]
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -830,8 +804,6 @@
         "$ref": "google.protobuf.FloatValue.jsonschema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -843,8 +815,6 @@
         "type": "integer"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -854,21 +824,15 @@
         "$ref": "google.protobuf.Int32Value.jsonschema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
     },
     "mapInt64Int64": {
       "additionalProperties": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -878,8 +842,6 @@
         "$ref": "google.protobuf.Int64Value.jsonschema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -889,8 +851,6 @@
         "$ref": "google.protobuf.ListValue.jsonschema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -900,8 +860,6 @@
         "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -912,8 +870,6 @@
       },
       "description": "Map",
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -936,8 +892,6 @@
         "title": "Null Value"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -947,8 +901,6 @@
         "type": "string"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -958,8 +910,6 @@
         "$ref": "google.protobuf.StringValue.jsonschema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -969,8 +919,6 @@
         "$ref": "google.protobuf.Struct.jsonschema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -980,8 +928,6 @@
         "$ref": "google.protobuf.Timestamp.jsonschema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -993,8 +939,6 @@
         "type": "integer"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -1004,21 +948,16 @@
         "$ref": "google.protobuf.UInt32Value.jsonschema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
     },
     "mapInt64Uint64": {
       "additionalProperties": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -1028,8 +967,6 @@
         "$ref": "google.protobuf.UInt64Value.jsonschema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -1039,8 +976,6 @@
         "$ref": "google.protobuf.Value.jsonschema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -1208,8 +1143,6 @@
     },
     "mapStringInt64": {
       "additionalProperties": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "propertyNames": {
@@ -1324,7 +1257,6 @@
     },
     "mapStringUint64": {
       "additionalProperties": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1540,8 +1472,6 @@
     },
     "mapUint32Int64": {
       "additionalProperties": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "propertyNames": {
@@ -1678,7 +1608,6 @@
     },
     "mapUint32Uint64": {
       "additionalProperties": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1716,7 +1645,6 @@
         "$ref": "google.protobuf.Any.jsonschema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1727,7 +1655,6 @@
         "type": "boolean"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1738,7 +1665,6 @@
         "$ref": "google.protobuf.BoolValue.jsonschema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1750,7 +1676,6 @@
         "type": "string"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1761,7 +1686,6 @@
         "$ref": "google.protobuf.BytesValue.jsonschema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1784,7 +1708,6 @@
         ]
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1795,7 +1718,6 @@
         "$ref": "google.protobuf.DoubleValue.jsonschema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1806,7 +1728,6 @@
         "$ref": "google.protobuf.Duration.jsonschema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1832,7 +1753,6 @@
         "title": "Nested Enum"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1857,7 +1777,6 @@
         ]
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1868,7 +1787,6 @@
         "$ref": "google.protobuf.FloatValue.jsonschema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1881,7 +1799,6 @@
         "type": "integer"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1892,7 +1809,6 @@
         "$ref": "google.protobuf.Int32Value.jsonschema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1900,12 +1816,9 @@
     },
     "mapUint64Int64": {
       "additionalProperties": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1916,7 +1829,6 @@
         "$ref": "google.protobuf.Int64Value.jsonschema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1927,7 +1839,6 @@
         "$ref": "google.protobuf.ListValue.jsonschema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1938,7 +1849,6 @@
         "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.jsonschema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1962,7 +1872,6 @@
         "title": "Null Value"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1973,7 +1882,6 @@
         "type": "string"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1984,7 +1892,6 @@
         "$ref": "google.protobuf.StringValue.jsonschema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1995,7 +1902,6 @@
         "$ref": "google.protobuf.Struct.jsonschema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -2006,7 +1912,6 @@
         "$ref": "google.protobuf.Timestamp.jsonschema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -2019,7 +1924,6 @@
         "type": "integer"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -2030,7 +1934,6 @@
         "$ref": "google.protobuf.UInt32Value.jsonschema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -2038,12 +1941,10 @@
     },
     "mapUint64Uint64": {
       "additionalProperties": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -2054,7 +1955,6 @@
         "$ref": "google.protobuf.UInt64Value.jsonschema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -2065,7 +1965,6 @@
         "$ref": "google.protobuf.Value.jsonschema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -2181,7 +2080,6 @@
     },
     "repeatedFixed64": {
       "items": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -2230,8 +2128,6 @@
     },
     "repeatedInt64": {
       "items": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "array"
@@ -2311,8 +2207,6 @@
     },
     "repeatedSfixed64": {
       "items": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "array"
@@ -2327,8 +2221,6 @@
     },
     "repeatedSint64": {
       "items": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "array"
@@ -2379,7 +2271,6 @@
     },
     "repeatedUint64": {
       "items": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -2441,7 +2332,6 @@
       "type": "integer"
     },
     "singleFixed64": {
-      "exclusiveMaximum": 18446744073709551616,
       "minimum": 0,
       "type": "integer"
     },
@@ -2475,8 +2365,6 @@
       "$ref": "google.protobuf.Int32Value.jsonschema.json"
     },
     "singleInt64": {
-      "exclusiveMaximum": 9223372036854775808,
-      "minimum": -9223372036854775808,
       "type": "integer"
     },
     "singleInt64Wrapper": {
@@ -2509,8 +2397,6 @@
       "type": "integer"
     },
     "singleSfixed64": {
-      "exclusiveMaximum": 9223372036854775808,
-      "minimum": -9223372036854775808,
       "type": "integer"
     },
     "singleSint32": {
@@ -2519,8 +2405,6 @@
       "type": "integer"
     },
     "singleSint64": {
-      "exclusiveMaximum": 9223372036854775808,
-      "minimum": -9223372036854775808,
       "type": "integer"
     },
     "singleString": {
@@ -2544,7 +2428,6 @@
       "$ref": "google.protobuf.UInt32Value.jsonschema.json"
     },
     "singleUint64": {
-      "exclusiveMaximum": 18446744073709551616,
       "minimum": 0,
       "type": "integer"
     },

--- a/internal/gen/jsonschema/bufext.cel.expr.conformance.proto3.TestAllTypes.schema.json
+++ b/internal/gen/jsonschema/bufext.cel.expr.conformance.proto3.TestAllTypes.schema.json
@@ -170,8 +170,6 @@
     },
     "map_bool_int64": {
       "additionalProperties": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "propertyNames": {
@@ -286,7 +284,6 @@
     },
     "map_bool_uint64": {
       "additionalProperties": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -502,8 +499,6 @@
     },
     "map_int32_int64": {
       "additionalProperties": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "propertyNames": {
@@ -640,7 +635,6 @@
     },
     "map_int32_uint64": {
       "additionalProperties": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -678,8 +672,6 @@
         "$ref": "google.protobuf.Any.schema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -689,8 +681,6 @@
         "type": "boolean"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -700,8 +690,6 @@
         "$ref": "google.protobuf.BoolValue.schema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -712,8 +700,6 @@
         "type": "string"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -723,8 +709,6 @@
         "$ref": "google.protobuf.BytesValue.schema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -746,8 +730,6 @@
         ]
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -757,8 +739,6 @@
         "$ref": "google.protobuf.DoubleValue.schema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -768,8 +748,6 @@
         "$ref": "google.protobuf.Duration.schema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -794,8 +772,6 @@
         "title": "Nested Enum"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -819,8 +795,6 @@
         ]
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -830,8 +804,6 @@
         "$ref": "google.protobuf.FloatValue.schema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -843,8 +815,6 @@
         "type": "integer"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -854,21 +824,15 @@
         "$ref": "google.protobuf.Int32Value.schema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
     },
     "map_int64_int64": {
       "additionalProperties": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -878,8 +842,6 @@
         "$ref": "google.protobuf.Int64Value.schema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -889,8 +851,6 @@
         "$ref": "google.protobuf.ListValue.schema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -900,8 +860,6 @@
         "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.schema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -912,8 +870,6 @@
       },
       "description": "Map",
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -936,8 +892,6 @@
         "title": "Null Value"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -947,8 +901,6 @@
         "type": "string"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -958,8 +910,6 @@
         "$ref": "google.protobuf.StringValue.schema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -969,8 +919,6 @@
         "$ref": "google.protobuf.Struct.schema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -980,8 +928,6 @@
         "$ref": "google.protobuf.Timestamp.schema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -993,8 +939,6 @@
         "type": "integer"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -1004,21 +948,16 @@
         "$ref": "google.protobuf.UInt32Value.schema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
     },
     "map_int64_uint64": {
       "additionalProperties": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -1028,8 +967,6 @@
         "$ref": "google.protobuf.UInt64Value.schema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -1039,8 +976,6 @@
         "$ref": "google.protobuf.Value.schema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "object"
@@ -1208,8 +1143,6 @@
     },
     "map_string_int64": {
       "additionalProperties": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "propertyNames": {
@@ -1324,7 +1257,6 @@
     },
     "map_string_uint64": {
       "additionalProperties": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1540,8 +1472,6 @@
     },
     "map_uint32_int64": {
       "additionalProperties": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "propertyNames": {
@@ -1678,7 +1608,6 @@
     },
     "map_uint32_uint64": {
       "additionalProperties": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1716,7 +1645,6 @@
         "$ref": "google.protobuf.Any.schema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1727,7 +1655,6 @@
         "type": "boolean"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1738,7 +1665,6 @@
         "$ref": "google.protobuf.BoolValue.schema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1750,7 +1676,6 @@
         "type": "string"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1761,7 +1686,6 @@
         "$ref": "google.protobuf.BytesValue.schema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1784,7 +1708,6 @@
         ]
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1795,7 +1718,6 @@
         "$ref": "google.protobuf.DoubleValue.schema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1806,7 +1728,6 @@
         "$ref": "google.protobuf.Duration.schema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1832,7 +1753,6 @@
         "title": "Nested Enum"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1857,7 +1777,6 @@
         ]
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1868,7 +1787,6 @@
         "$ref": "google.protobuf.FloatValue.schema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1881,7 +1799,6 @@
         "type": "integer"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1892,7 +1809,6 @@
         "$ref": "google.protobuf.Int32Value.schema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1900,12 +1816,9 @@
     },
     "map_uint64_int64": {
       "additionalProperties": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1916,7 +1829,6 @@
         "$ref": "google.protobuf.Int64Value.schema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1927,7 +1839,6 @@
         "$ref": "google.protobuf.ListValue.schema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1938,7 +1849,6 @@
         "$ref": "bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.schema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1962,7 +1872,6 @@
         "title": "Null Value"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1973,7 +1882,6 @@
         "type": "string"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1984,7 +1892,6 @@
         "$ref": "google.protobuf.StringValue.schema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -1995,7 +1902,6 @@
         "$ref": "google.protobuf.Struct.schema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -2006,7 +1912,6 @@
         "$ref": "google.protobuf.Timestamp.schema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -2019,7 +1924,6 @@
         "type": "integer"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -2030,7 +1934,6 @@
         "$ref": "google.protobuf.UInt32Value.schema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -2038,12 +1941,10 @@
     },
     "map_uint64_uint64": {
       "additionalProperties": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -2054,7 +1955,6 @@
         "$ref": "google.protobuf.UInt64Value.schema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -2065,7 +1965,6 @@
         "$ref": "google.protobuf.Value.schema.json"
       },
       "propertyNames": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -2181,7 +2080,6 @@
     },
     "repeated_fixed64": {
       "items": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -2230,8 +2128,6 @@
     },
     "repeated_int64": {
       "items": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "array"
@@ -2311,8 +2207,6 @@
     },
     "repeated_sfixed64": {
       "items": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "array"
@@ -2327,8 +2221,6 @@
     },
     "repeated_sint64": {
       "items": {
-        "exclusiveMaximum": 9223372036854775808,
-        "minimum": -9223372036854775808,
         "type": "integer"
       },
       "type": "array"
@@ -2379,7 +2271,6 @@
     },
     "repeated_uint64": {
       "items": {
-        "exclusiveMaximum": 18446744073709551616,
         "minimum": 0,
         "type": "integer"
       },
@@ -2441,7 +2332,6 @@
       "type": "integer"
     },
     "single_fixed64": {
-      "exclusiveMaximum": 18446744073709551616,
       "minimum": 0,
       "type": "integer"
     },
@@ -2475,8 +2365,6 @@
       "$ref": "google.protobuf.Int32Value.schema.json"
     },
     "single_int64": {
-      "exclusiveMaximum": 9223372036854775808,
-      "minimum": -9223372036854775808,
       "type": "integer"
     },
     "single_int64_wrapper": {
@@ -2509,8 +2397,6 @@
       "type": "integer"
     },
     "single_sfixed64": {
-      "exclusiveMaximum": 9223372036854775808,
-      "minimum": -9223372036854775808,
       "type": "integer"
     },
     "single_sint32": {
@@ -2519,8 +2405,6 @@
       "type": "integer"
     },
     "single_sint64": {
-      "exclusiveMaximum": 9223372036854775808,
-      "minimum": -9223372036854775808,
       "type": "integer"
     },
     "single_string": {
@@ -2544,7 +2428,6 @@
       "$ref": "google.protobuf.UInt32Value.schema.json"
     },
     "single_uint64": {
-      "exclusiveMaximum": 18446744073709551616,
       "minimum": 0,
       "type": "integer"
     },

--- a/internal/gen/jsonschema/google.protobuf.Int64Value.jsonschema.json
+++ b/internal/gen/jsonschema/google.protobuf.Int64Value.jsonschema.json
@@ -2,8 +2,6 @@
   "$id": "google.protobuf.Int64Value.jsonschema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "The int64 value.",
-  "exclusiveMaximum": 9223372036854775808,
-  "minimum": -9223372036854775808,
   "title": "Int64 Value",
   "type": "integer"
 }

--- a/internal/gen/jsonschema/google.protobuf.Int64Value.schema.json
+++ b/internal/gen/jsonschema/google.protobuf.Int64Value.schema.json
@@ -2,8 +2,6 @@
   "$id": "google.protobuf.Int64Value.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "The int64 value.",
-  "exclusiveMaximum": 9223372036854775808,
-  "minimum": -9223372036854775808,
   "title": "Int64 Value",
   "type": "integer"
 }

--- a/internal/gen/jsonschema/google.protobuf.UInt64Value.jsonschema.json
+++ b/internal/gen/jsonschema/google.protobuf.UInt64Value.jsonschema.json
@@ -2,7 +2,6 @@
   "$id": "google.protobuf.UInt64Value.jsonschema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "The uint64 value.",
-  "exclusiveMaximum": 18446744073709551616,
   "minimum": 0,
   "title": "U Int64 Value",
   "type": "integer"

--- a/internal/gen/jsonschema/google.protobuf.UInt64Value.schema.json
+++ b/internal/gen/jsonschema/google.protobuf.UInt64Value.schema.json
@@ -2,7 +2,6 @@
   "$id": "google.protobuf.UInt64Value.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "The uint64 value.",
-  "exclusiveMaximum": 18446744073709551616,
   "minimum": 0,
   "title": "U Int64 Value",
   "type": "integer"

--- a/internal/protoschema/jsonschema/jsonschema.go
+++ b/internal/protoschema/jsonschema/jsonschema.go
@@ -483,6 +483,8 @@ func generateIntValidation[T int32 | int64](
 	bits int,
 	schema map[string]any,
 ) {
+	// TODO: Consider suppressing the number output if all valid values
+	// are out of the range [jsMinInt, jsMaxInt].
 	numberSchema := map[string]any{
 		"type": jsInteger,
 	}
@@ -623,6 +625,8 @@ func generateUintValidation[T uint32 | uint64](
 	bits int,
 	schema map[string]any,
 ) {
+	// TODO: Consider suppressing the number output if all valid values
+	// are out of the range [0, jsMaxUint].
 	numberSchema := map[string]any{
 		"type": jsInteger,
 	}

--- a/internal/protoschema/jsonschema/jsonschema.go
+++ b/internal/protoschema/jsonschema/jsonschema.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"maps"
 	"math"
-	"math/big"
 	"slices"
 	"strings"
 	"unicode"
@@ -37,6 +36,12 @@ const (
 	jsNumber  = "number"
 	jsObject  = "object"
 	jsString  = "string"
+
+	// Any integers greater or less than these extrema cannot be safely represented
+	// according to RFC8259.
+	jsMaxInt  = 1<<53 - 1
+	jsMinInt  = -jsMaxInt
+	jsMaxUint = uint64(jsMaxInt)
 )
 
 type FieldVisibility int
@@ -45,11 +50,6 @@ const (
 	FieldVisible FieldVisibility = iota
 	FieldHide
 	FieldIgnore
-)
-
-var (
-	exclusiveMaxUint64 = big.NewInt(0).Exp(big.NewInt(2), big.NewInt(64), nil)
-	exclusiveMaxInt64  = uint64(1) << 63
 )
 
 type GeneratorOption func(*jsonSchemaGenerator)
@@ -501,8 +501,11 @@ func generateIntValidation[T int32 | int64](
 			isOr = rules.GetLte() <= rules.GetGt()
 		}
 		if isOr {
-			orNumberSchema = map[string]any{"exclusiveMinimum": rules.GetGt()}
-		} else {
+			orNumberSchema = make(map[string]any)
+			if int64(rules.GetGt()) >= jsMinInt {
+				orNumberSchema["exclusiveMinimum"] = rules.GetGt()
+			}
+		} else if int64(rules.GetGt()) >= jsMinInt {
 			numberSchema["exclusiveMinimum"] = rules.GetGt()
 		}
 	case rules.HasGte():
@@ -514,20 +517,31 @@ func generateIntValidation[T int32 | int64](
 			isOr = rules.GetLte() < rules.GetGte()
 		}
 		if isOr {
-			orNumberSchema = map[string]any{"minimum": rules.GetGte()}
-		} else {
+			orNumberSchema = make(map[string]any)
+			if int64(rules.GetGte()) > jsMinInt {
+				orNumberSchema["minimum"] = rules.GetGte()
+			}
+		} else if int64(rules.GetGte()) > jsMinInt {
 			numberSchema["minimum"] = rules.GetGte()
 		}
 	default:
-		numberSchema["minimum"] = minVal
+		if bits <= 53 {
+			numberSchema["minimum"] = minVal
+		}
 	}
 	switch {
 	case rules.HasLt():
-		numberSchema["exclusiveMaximum"] = rules.GetLt()
+		if int64(rules.GetLt()) <= jsMaxInt {
+			numberSchema["exclusiveMaximum"] = rules.GetLt()
+		}
 	case rules.HasLte():
-		numberSchema["maximum"] = rules.GetLte()
+		if int64(rules.GetLte()) < jsMaxInt {
+			numberSchema["maximum"] = rules.GetLte()
+		}
 	default:
-		numberSchema["exclusiveMaximum"] = maxExclVal
+		if bits < 53 {
+			numberSchema["exclusiveMaximum"] = maxExclVal
+		}
 	}
 
 	anyOf := []map[string]any{
@@ -535,8 +549,10 @@ func generateIntValidation[T int32 | int64](
 	}
 
 	if orNumberSchema != nil {
-		numberSchema["minimum"] = minVal
-		orNumberSchema["exclusiveMaximum"] = maxExclVal
+		if bits < 53 {
+			numberSchema["minimum"] = minVal
+			orNumberSchema["exclusiveMaximum"] = maxExclVal
+		}
 		orNumberSchema["type"] = jsInteger
 		anyOf = append(anyOf, orNumberSchema)
 	}
@@ -585,11 +601,9 @@ func (p *jsonSchemaGenerator) generateInt64Validation(field protoreflect.FieldDe
 	default:
 		if p.strict {
 			schema["type"] = jsInteger
-			schema["minimum"] = math.MinInt64
-			schema["exclusiveMaximum"] = exclusiveMaxInt64
 		} else {
 			schema["anyOf"] = []map[string]any{
-				{"type": jsInteger, "minimum": math.MinInt64, "exclusiveMaximum": exclusiveMaxInt64},
+				{"type": jsInteger},
 				{"type": jsString, "pattern": "^-?[0-9]+$"},
 			}
 		}
@@ -625,7 +639,10 @@ func generateUintValidation[T uint32 | uint64](
 			isOr = rules.GetLte() <= rules.GetGt()
 		}
 		if isOr {
-			orNumberSchema = map[string]any{"exclusiveMinimum": rules.GetGt()}
+			orNumberSchema = make(map[string]any)
+			if uint64(rules.GetGt()) <= jsMaxUint {
+				orNumberSchema["exclusiveMinimum"] = rules.GetGt()
+			}
 		} else {
 			numberSchema["exclusiveMinimum"] = rules.GetGt()
 		}
@@ -647,10 +664,14 @@ func generateUintValidation[T uint32 | uint64](
 	}
 	switch {
 	case rules.HasLt():
-		numberSchema["exclusiveMaximum"] = rules.GetLt()
+		if uint64(rules.GetLt()) <= jsMaxUint {
+			numberSchema["exclusiveMaximum"] = rules.GetLt()
+		}
 	case rules.HasLte():
-		numberSchema["maximum"] = rules.GetLte()
-	default:
+		if uint64(rules.GetLte()) < jsMaxUint {
+			numberSchema["maximum"] = rules.GetLte()
+		}
+	case bits < 53:
 		numberSchema["exclusiveMaximum"] = maxExclVal
 	}
 
@@ -659,7 +680,9 @@ func generateUintValidation[T uint32 | uint64](
 	}
 	if orNumberSchema != nil {
 		numberSchema["minimum"] = 0
-		orNumberSchema["exclusiveMaximum"] = maxExclVal
+		if bits < 53 {
+			orNumberSchema["exclusiveMaximum"] = maxExclVal
+		}
 		orNumberSchema["type"] = jsInteger
 		anyOf = append(anyOf, orNumberSchema)
 	}
@@ -706,10 +729,9 @@ func (p *jsonSchemaGenerator) generateUint64Validation(field protoreflect.FieldD
 		if p.strict {
 			schema["type"] = jsInteger
 			schema["minimum"] = 0
-			schema["exclusiveMaximum"] = exclusiveMaxUint64
 		} else {
 			schema["anyOf"] = []map[string]any{
-				{"type": jsInteger, "minimum": 0, "exclusiveMaximum": exclusiveMaxUint64},
+				{"type": jsInteger, "minimum": 0},
 				{"type": jsString, "pattern": "^[0-9]+$"},
 			}
 		}

--- a/internal/testdata/jsonschema/buf.protoschema.test.v1.ConstraintTest.jsonschema.json
+++ b/internal/testdata/jsonschema/buf.protoschema.test.v1.ConstraintTest.jsonschema.json
@@ -68,7 +68,6 @@
           "enum": [
             5
           ],
-          "exclusiveMaximum": 18446744073709552000,
           "minimum": 0,
           "type": "integer"
         },
@@ -118,8 +117,6 @@
           "enum": [
             5
           ],
-          "exclusiveMaximum": 9223372036854775808,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -150,8 +147,6 @@
           "enum": [
             5
           ],
-          "exclusiveMaximum": 9223372036854775808,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -182,8 +177,6 @@
           "enum": [
             5
           ],
-          "exclusiveMaximum": 9223372036854775808,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -220,7 +213,6 @@
           "enum": [
             5
           ],
-          "exclusiveMaximum": 18446744073709552000,
           "minimum": 0,
           "type": "integer"
         },
@@ -343,7 +335,6 @@
     "^(gt_fixed64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 18446744073709552000,
           "exclusiveMinimum": 5,
           "type": "integer"
         },
@@ -389,7 +380,6 @@
     "^(gt_int64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854775808,
           "exclusiveMinimum": 5,
           "type": "integer"
         },
@@ -415,7 +405,6 @@
     "^(gt_sfixed64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854775808,
           "exclusiveMinimum": 5,
           "type": "integer"
         },
@@ -441,7 +430,6 @@
     "^(gt_sint64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854775808,
           "exclusiveMinimum": 5,
           "type": "integer"
         },
@@ -467,7 +455,6 @@
     "^(gt_uint64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 18446744073709552000,
           "exclusiveMinimum": 5,
           "type": "integer"
         },
@@ -512,7 +499,6 @@
     "^(gte_fixed64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 18446744073709552000,
           "minimum": 5,
           "type": "integer"
         },
@@ -558,7 +544,6 @@
     "^(gte_int64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854775808,
           "minimum": 5,
           "type": "integer"
         },
@@ -584,7 +569,6 @@
     "^(gte_sfixed64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854775808,
           "minimum": 5,
           "type": "integer"
         },
@@ -610,7 +594,6 @@
     "^(gte_sint64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854775808,
           "minimum": 5,
           "type": "integer"
         },
@@ -636,7 +619,6 @@
     "^(gte_uint64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 18446744073709552000,
           "minimum": 5,
           "type": "integer"
         },
@@ -735,7 +717,6 @@
             1,
             2
           ],
-          "exclusiveMaximum": 18446744073709552000,
           "minimum": 0,
           "type": "integer"
         },
@@ -788,8 +769,6 @@
             1,
             2
           ],
-          "exclusiveMaximum": 9223372036854775808,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -839,8 +818,6 @@
             1,
             2
           ],
-          "exclusiveMaximum": 9223372036854775808,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -873,8 +850,6 @@
             1,
             2
           ],
-          "exclusiveMaximum": 9223372036854775808,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -914,7 +889,6 @@
             1,
             2
           ],
-          "exclusiveMaximum": 18446744073709552000,
           "minimum": 0,
           "type": "integer"
         },
@@ -1104,11 +1078,9 @@
       "anyOf": [
         {
           "exclusiveMaximum": 1,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
-          "exclusiveMaximum": 9223372036854775808,
           "exclusiveMinimum": 5,
           "type": "integer"
         },
@@ -1144,7 +1116,6 @@
           "type": "integer"
         },
         {
-          "exclusiveMaximum": 18446744073709552000,
           "exclusiveMinimum": 5,
           "type": "integer"
         },
@@ -1171,7 +1142,6 @@
       "anyOf": [
         {
           "exclusiveMaximum": 5,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -1197,7 +1167,6 @@
       "anyOf": [
         {
           "exclusiveMaximum": 5,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -1223,7 +1192,6 @@
       "anyOf": [
         {
           "exclusiveMaximum": 5,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -1340,7 +1308,6 @@
       "anyOf": [
         {
           "maximum": 5,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -1366,7 +1333,6 @@
       "anyOf": [
         {
           "maximum": 5,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -1392,7 +1358,6 @@
       "anyOf": [
         {
           "maximum": 5,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -1582,7 +1547,6 @@
           "enum": [
             5
           ],
-          "exclusiveMaximum": 18446744073709552000,
           "minimum": 0,
           "type": "integer"
         },
@@ -1632,8 +1596,6 @@
           "enum": [
             5
           ],
-          "exclusiveMaximum": 9223372036854775808,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -1664,8 +1626,6 @@
           "enum": [
             5
           ],
-          "exclusiveMaximum": 9223372036854775808,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -1696,8 +1656,6 @@
           "enum": [
             5
           ],
-          "exclusiveMaximum": 9223372036854775808,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -1734,7 +1692,6 @@
           "enum": [
             5
           ],
-          "exclusiveMaximum": 18446744073709552000,
           "minimum": 0,
           "type": "integer"
         },
@@ -1857,7 +1814,6 @@
     "gtFixed64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 18446744073709552000,
           "exclusiveMinimum": 5,
           "type": "integer"
         },
@@ -1903,7 +1859,6 @@
     "gtInt64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854775808,
           "exclusiveMinimum": 5,
           "type": "integer"
         },
@@ -1929,7 +1884,6 @@
     "gtSfixed64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854775808,
           "exclusiveMinimum": 5,
           "type": "integer"
         },
@@ -1955,7 +1909,6 @@
     "gtSint64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854775808,
           "exclusiveMinimum": 5,
           "type": "integer"
         },
@@ -1981,7 +1934,6 @@
     "gtUint64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 18446744073709552000,
           "exclusiveMinimum": 5,
           "type": "integer"
         },
@@ -2026,7 +1978,6 @@
     "gteFixed64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 18446744073709552000,
           "minimum": 5,
           "type": "integer"
         },
@@ -2072,7 +2023,6 @@
     "gteInt64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854775808,
           "minimum": 5,
           "type": "integer"
         },
@@ -2098,7 +2048,6 @@
     "gteSfixed64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854775808,
           "minimum": 5,
           "type": "integer"
         },
@@ -2124,7 +2073,6 @@
     "gteSint64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854775808,
           "minimum": 5,
           "type": "integer"
         },
@@ -2150,7 +2098,6 @@
     "gteUint64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 18446744073709552000,
           "minimum": 5,
           "type": "integer"
         },
@@ -2249,7 +2196,6 @@
             1,
             2
           ],
-          "exclusiveMaximum": 18446744073709552000,
           "minimum": 0,
           "type": "integer"
         },
@@ -2302,8 +2248,6 @@
             1,
             2
           ],
-          "exclusiveMaximum": 9223372036854775808,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -2353,8 +2297,6 @@
             1,
             2
           ],
-          "exclusiveMaximum": 9223372036854775808,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -2387,8 +2329,6 @@
             1,
             2
           ],
-          "exclusiveMaximum": 9223372036854775808,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -2428,7 +2368,6 @@
             1,
             2
           ],
-          "exclusiveMaximum": 18446744073709552000,
           "minimum": 0,
           "type": "integer"
         },
@@ -2618,11 +2557,9 @@
       "anyOf": [
         {
           "exclusiveMaximum": 1,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
-          "exclusiveMaximum": 9223372036854775808,
           "exclusiveMinimum": 5,
           "type": "integer"
         },
@@ -2658,7 +2595,6 @@
           "type": "integer"
         },
         {
-          "exclusiveMaximum": 18446744073709552000,
           "exclusiveMinimum": 5,
           "type": "integer"
         },
@@ -2685,7 +2621,6 @@
       "anyOf": [
         {
           "exclusiveMaximum": 5,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -2711,7 +2646,6 @@
       "anyOf": [
         {
           "exclusiveMaximum": 5,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -2737,7 +2671,6 @@
       "anyOf": [
         {
           "exclusiveMaximum": 5,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -2854,7 +2787,6 @@
       "anyOf": [
         {
           "maximum": 5,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -2880,7 +2812,6 @@
       "anyOf": [
         {
           "maximum": 5,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -2906,7 +2837,6 @@
       "anyOf": [
         {
           "maximum": 5,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {

--- a/internal/testdata/jsonschema/buf.protoschema.test.v1.ConstraintTest.schema.json
+++ b/internal/testdata/jsonschema/buf.protoschema.test.v1.ConstraintTest.schema.json
@@ -68,7 +68,6 @@
           "enum": [
             5
           ],
-          "exclusiveMaximum": 18446744073709552000,
           "minimum": 0,
           "type": "integer"
         },
@@ -118,8 +117,6 @@
           "enum": [
             5
           ],
-          "exclusiveMaximum": 9223372036854775808,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -150,8 +147,6 @@
           "enum": [
             5
           ],
-          "exclusiveMaximum": 9223372036854775808,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -182,8 +177,6 @@
           "enum": [
             5
           ],
-          "exclusiveMaximum": 9223372036854775808,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -220,7 +213,6 @@
           "enum": [
             5
           ],
-          "exclusiveMaximum": 18446744073709552000,
           "minimum": 0,
           "type": "integer"
         },
@@ -343,7 +335,6 @@
     "^(gtFixed64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 18446744073709552000,
           "exclusiveMinimum": 5,
           "type": "integer"
         },
@@ -389,7 +380,6 @@
     "^(gtInt64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854775808,
           "exclusiveMinimum": 5,
           "type": "integer"
         },
@@ -415,7 +405,6 @@
     "^(gtSfixed64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854775808,
           "exclusiveMinimum": 5,
           "type": "integer"
         },
@@ -441,7 +430,6 @@
     "^(gtSint64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854775808,
           "exclusiveMinimum": 5,
           "type": "integer"
         },
@@ -467,7 +455,6 @@
     "^(gtUint64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 18446744073709552000,
           "exclusiveMinimum": 5,
           "type": "integer"
         },
@@ -512,7 +499,6 @@
     "^(gteFixed64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 18446744073709552000,
           "minimum": 5,
           "type": "integer"
         },
@@ -558,7 +544,6 @@
     "^(gteInt64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854775808,
           "minimum": 5,
           "type": "integer"
         },
@@ -584,7 +569,6 @@
     "^(gteSfixed64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854775808,
           "minimum": 5,
           "type": "integer"
         },
@@ -610,7 +594,6 @@
     "^(gteSint64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854775808,
           "minimum": 5,
           "type": "integer"
         },
@@ -636,7 +619,6 @@
     "^(gteUint64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 18446744073709552000,
           "minimum": 5,
           "type": "integer"
         },
@@ -735,7 +717,6 @@
             1,
             2
           ],
-          "exclusiveMaximum": 18446744073709552000,
           "minimum": 0,
           "type": "integer"
         },
@@ -788,8 +769,6 @@
             1,
             2
           ],
-          "exclusiveMaximum": 9223372036854775808,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -839,8 +818,6 @@
             1,
             2
           ],
-          "exclusiveMaximum": 9223372036854775808,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -873,8 +850,6 @@
             1,
             2
           ],
-          "exclusiveMaximum": 9223372036854775808,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -914,7 +889,6 @@
             1,
             2
           ],
-          "exclusiveMaximum": 18446744073709552000,
           "minimum": 0,
           "type": "integer"
         },
@@ -1104,11 +1078,9 @@
       "anyOf": [
         {
           "exclusiveMaximum": 1,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
-          "exclusiveMaximum": 9223372036854775808,
           "exclusiveMinimum": 5,
           "type": "integer"
         },
@@ -1144,7 +1116,6 @@
           "type": "integer"
         },
         {
-          "exclusiveMaximum": 18446744073709552000,
           "exclusiveMinimum": 5,
           "type": "integer"
         },
@@ -1171,7 +1142,6 @@
       "anyOf": [
         {
           "exclusiveMaximum": 5,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -1197,7 +1167,6 @@
       "anyOf": [
         {
           "exclusiveMaximum": 5,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -1223,7 +1192,6 @@
       "anyOf": [
         {
           "exclusiveMaximum": 5,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -1340,7 +1308,6 @@
       "anyOf": [
         {
           "maximum": 5,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -1366,7 +1333,6 @@
       "anyOf": [
         {
           "maximum": 5,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -1392,7 +1358,6 @@
       "anyOf": [
         {
           "maximum": 5,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -1582,7 +1547,6 @@
           "enum": [
             5
           ],
-          "exclusiveMaximum": 18446744073709552000,
           "minimum": 0,
           "type": "integer"
         },
@@ -1632,8 +1596,6 @@
           "enum": [
             5
           ],
-          "exclusiveMaximum": 9223372036854775808,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -1664,8 +1626,6 @@
           "enum": [
             5
           ],
-          "exclusiveMaximum": 9223372036854775808,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -1696,8 +1656,6 @@
           "enum": [
             5
           ],
-          "exclusiveMaximum": 9223372036854775808,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -1734,7 +1692,6 @@
           "enum": [
             5
           ],
-          "exclusiveMaximum": 18446744073709552000,
           "minimum": 0,
           "type": "integer"
         },
@@ -1857,7 +1814,6 @@
     "gt_fixed64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 18446744073709552000,
           "exclusiveMinimum": 5,
           "type": "integer"
         },
@@ -1903,7 +1859,6 @@
     "gt_int64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854775808,
           "exclusiveMinimum": 5,
           "type": "integer"
         },
@@ -1929,7 +1884,6 @@
     "gt_sfixed64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854775808,
           "exclusiveMinimum": 5,
           "type": "integer"
         },
@@ -1955,7 +1909,6 @@
     "gt_sint64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854775808,
           "exclusiveMinimum": 5,
           "type": "integer"
         },
@@ -1981,7 +1934,6 @@
     "gt_uint64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 18446744073709552000,
           "exclusiveMinimum": 5,
           "type": "integer"
         },
@@ -2026,7 +1978,6 @@
     "gte_fixed64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 18446744073709552000,
           "minimum": 5,
           "type": "integer"
         },
@@ -2072,7 +2023,6 @@
     "gte_int64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854775808,
           "minimum": 5,
           "type": "integer"
         },
@@ -2098,7 +2048,6 @@
     "gte_sfixed64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854775808,
           "minimum": 5,
           "type": "integer"
         },
@@ -2124,7 +2073,6 @@
     "gte_sint64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854775808,
           "minimum": 5,
           "type": "integer"
         },
@@ -2150,7 +2098,6 @@
     "gte_uint64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 18446744073709552000,
           "minimum": 5,
           "type": "integer"
         },
@@ -2249,7 +2196,6 @@
             1,
             2
           ],
-          "exclusiveMaximum": 18446744073709552000,
           "minimum": 0,
           "type": "integer"
         },
@@ -2302,8 +2248,6 @@
             1,
             2
           ],
-          "exclusiveMaximum": 9223372036854775808,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -2353,8 +2297,6 @@
             1,
             2
           ],
-          "exclusiveMaximum": 9223372036854775808,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -2387,8 +2329,6 @@
             1,
             2
           ],
-          "exclusiveMaximum": 9223372036854775808,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -2428,7 +2368,6 @@
             1,
             2
           ],
-          "exclusiveMaximum": 18446744073709552000,
           "minimum": 0,
           "type": "integer"
         },
@@ -2618,11 +2557,9 @@
       "anyOf": [
         {
           "exclusiveMaximum": 1,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
-          "exclusiveMaximum": 9223372036854775808,
           "exclusiveMinimum": 5,
           "type": "integer"
         },
@@ -2658,7 +2595,6 @@
           "type": "integer"
         },
         {
-          "exclusiveMaximum": 18446744073709552000,
           "exclusiveMinimum": 5,
           "type": "integer"
         },
@@ -2685,7 +2621,6 @@
       "anyOf": [
         {
           "exclusiveMaximum": 5,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -2711,7 +2646,6 @@
       "anyOf": [
         {
           "exclusiveMaximum": 5,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -2737,7 +2671,6 @@
       "anyOf": [
         {
           "exclusiveMaximum": 5,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -2854,7 +2787,6 @@
       "anyOf": [
         {
           "maximum": 5,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -2880,7 +2812,6 @@
       "anyOf": [
         {
           "maximum": 5,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -2906,7 +2837,6 @@
       "anyOf": [
         {
           "maximum": 5,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {

--- a/internal/testdata/jsonschema/bufext.cel.expr.conformance.proto3.TestAllTypes.jsonschema.json
+++ b/internal/testdata/jsonschema/bufext.cel.expr.conformance.proto3.TestAllTypes.jsonschema.json
@@ -186,8 +186,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -318,7 +316,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -660,8 +657,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -902,7 +897,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -972,8 +966,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -991,8 +983,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1010,8 +1000,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1030,8 +1018,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1049,8 +1035,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1083,8 +1067,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1102,8 +1084,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1121,8 +1101,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1155,8 +1133,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1191,8 +1167,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1210,8 +1184,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1239,8 +1211,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1258,8 +1228,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1274,8 +1242,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1287,8 +1253,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1306,8 +1270,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1325,8 +1287,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1344,8 +1304,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1364,8 +1322,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1396,8 +1352,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1415,8 +1369,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1434,8 +1386,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1453,8 +1403,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1472,8 +1420,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1501,8 +1447,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1520,8 +1464,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1536,7 +1478,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -1549,8 +1490,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1568,8 +1507,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1587,8 +1524,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1778,8 +1713,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1910,7 +1843,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2252,8 +2184,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -2494,7 +2424,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2564,7 +2493,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2583,7 +2511,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2602,7 +2529,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2622,7 +2548,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2641,7 +2566,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2675,7 +2599,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2694,7 +2617,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2713,7 +2635,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2747,7 +2668,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2783,7 +2703,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2802,7 +2721,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2831,7 +2749,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2850,7 +2767,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2866,8 +2782,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -2879,7 +2793,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2898,7 +2811,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2917,7 +2829,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2936,7 +2847,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2968,7 +2878,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2987,7 +2896,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -3006,7 +2914,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -3025,7 +2932,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -3044,7 +2950,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -3073,7 +2978,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -3092,7 +2996,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -3108,7 +3011,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -3121,7 +3023,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -3140,7 +3041,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -3159,7 +3059,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -3295,7 +3194,6 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -3363,8 +3261,6 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -3460,8 +3356,6 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -3492,8 +3386,6 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -3560,7 +3452,6 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -3645,7 +3536,6 @@
     "^(single_fixed64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 18446744073709551616,
           "minimum": 0,
           "type": "integer"
         },
@@ -3701,8 +3591,6 @@
     "^(single_int64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854775808,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -3753,8 +3641,6 @@
     "^(single_sfixed64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854775808,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -3781,8 +3667,6 @@
     "^(single_sint64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854775808,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -3825,7 +3709,6 @@
     "^(single_uint64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 18446744073709551616,
           "minimum": 0,
           "type": "integer"
         },
@@ -4048,8 +3931,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -4180,7 +4061,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -4522,8 +4402,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -4764,7 +4642,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -4834,8 +4711,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -4853,8 +4728,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -4872,8 +4745,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -4892,8 +4763,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -4911,8 +4780,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -4945,8 +4812,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -4964,8 +4829,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -4983,8 +4846,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5017,8 +4878,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5053,8 +4912,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5072,8 +4929,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5101,8 +4956,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5120,8 +4973,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5136,8 +4987,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5149,8 +4998,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5168,8 +5015,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5187,8 +5032,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5206,8 +5049,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5226,8 +5067,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5258,8 +5097,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5277,8 +5114,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5296,8 +5131,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5315,8 +5148,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5334,8 +5165,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5363,8 +5192,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5382,8 +5209,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5398,7 +5223,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5411,8 +5235,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5430,8 +5252,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5449,8 +5269,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5640,8 +5458,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5772,7 +5588,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6114,8 +5929,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -6356,7 +6169,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6426,7 +6238,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6445,7 +6256,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6464,7 +6274,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6484,7 +6293,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6503,7 +6311,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6537,7 +6344,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6556,7 +6362,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6575,7 +6380,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6609,7 +6413,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6645,7 +6448,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6664,7 +6466,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6693,7 +6494,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6712,7 +6512,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6728,8 +6527,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -6741,7 +6538,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6760,7 +6556,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6779,7 +6574,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6798,7 +6592,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6830,7 +6623,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6849,7 +6641,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6868,7 +6659,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6887,7 +6677,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6906,7 +6695,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6935,7 +6723,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6954,7 +6741,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6970,7 +6756,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6983,7 +6768,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -7002,7 +6786,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -7021,7 +6804,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -7157,7 +6939,6 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -7225,8 +7006,6 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -7322,8 +7101,6 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -7354,8 +7131,6 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -7422,7 +7197,6 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -7507,7 +7281,6 @@
     "singleFixed64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 18446744073709551616,
           "minimum": 0,
           "type": "integer"
         },
@@ -7563,8 +7336,6 @@
     "singleInt64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854775808,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -7615,8 +7386,6 @@
     "singleSfixed64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854775808,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -7643,8 +7412,6 @@
     "singleSint64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854775808,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -7687,7 +7454,6 @@
     "singleUint64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 18446744073709551616,
           "minimum": 0,
           "type": "integer"
         },

--- a/internal/testdata/jsonschema/bufext.cel.expr.conformance.proto3.TestAllTypes.schema.json
+++ b/internal/testdata/jsonschema/bufext.cel.expr.conformance.proto3.TestAllTypes.schema.json
@@ -186,8 +186,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -318,7 +316,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -660,8 +657,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -902,7 +897,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -972,8 +966,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -991,8 +983,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1010,8 +1000,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1030,8 +1018,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1049,8 +1035,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1083,8 +1067,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1102,8 +1084,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1121,8 +1101,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1155,8 +1133,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1191,8 +1167,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1210,8 +1184,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1239,8 +1211,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1258,8 +1228,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1274,8 +1242,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1287,8 +1253,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1306,8 +1270,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1325,8 +1287,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1344,8 +1304,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1364,8 +1322,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1396,8 +1352,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1415,8 +1369,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1434,8 +1386,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1453,8 +1403,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1472,8 +1420,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1501,8 +1447,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1520,8 +1464,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1536,7 +1478,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -1549,8 +1490,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1568,8 +1507,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1587,8 +1524,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1778,8 +1713,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -1910,7 +1843,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2252,8 +2184,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -2494,7 +2424,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2564,7 +2493,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2583,7 +2511,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2602,7 +2529,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2622,7 +2548,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2641,7 +2566,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2675,7 +2599,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2694,7 +2617,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2713,7 +2635,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2747,7 +2668,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2783,7 +2703,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2802,7 +2721,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2831,7 +2749,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2850,7 +2767,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2866,8 +2782,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -2879,7 +2793,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2898,7 +2811,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2917,7 +2829,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2936,7 +2847,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2968,7 +2878,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -2987,7 +2896,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -3006,7 +2914,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -3025,7 +2932,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -3044,7 +2950,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -3073,7 +2978,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -3092,7 +2996,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -3108,7 +3011,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -3121,7 +3023,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -3140,7 +3041,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -3159,7 +3059,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -3295,7 +3194,6 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -3363,8 +3261,6 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -3460,8 +3356,6 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -3492,8 +3386,6 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -3560,7 +3452,6 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -3645,7 +3536,6 @@
     "^(singleFixed64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 18446744073709551616,
           "minimum": 0,
           "type": "integer"
         },
@@ -3701,8 +3591,6 @@
     "^(singleInt64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854775808,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -3753,8 +3641,6 @@
     "^(singleSfixed64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854775808,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -3781,8 +3667,6 @@
     "^(singleSint64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854775808,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -3825,7 +3709,6 @@
     "^(singleUint64)$": {
       "anyOf": [
         {
-          "exclusiveMaximum": 18446744073709551616,
           "minimum": 0,
           "type": "integer"
         },
@@ -4048,8 +3931,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -4180,7 +4061,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -4522,8 +4402,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -4764,7 +4642,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -4834,8 +4711,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -4853,8 +4728,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -4872,8 +4745,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -4892,8 +4763,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -4911,8 +4780,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -4945,8 +4812,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -4964,8 +4829,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -4983,8 +4846,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5017,8 +4878,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5053,8 +4912,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5072,8 +4929,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5101,8 +4956,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5120,8 +4973,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5136,8 +4987,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5149,8 +4998,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5168,8 +5015,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5187,8 +5032,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5206,8 +5049,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5226,8 +5067,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5258,8 +5097,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5277,8 +5114,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5296,8 +5131,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5315,8 +5148,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5334,8 +5165,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5363,8 +5192,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5382,8 +5209,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5398,7 +5223,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -5411,8 +5235,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5430,8 +5252,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5449,8 +5269,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5640,8 +5458,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -5772,7 +5588,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6114,8 +5929,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -6356,7 +6169,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6426,7 +6238,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6445,7 +6256,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6464,7 +6274,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6484,7 +6293,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6503,7 +6311,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6537,7 +6344,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6556,7 +6362,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6575,7 +6380,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6609,7 +6413,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6645,7 +6448,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6664,7 +6466,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6693,7 +6494,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6712,7 +6512,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6728,8 +6527,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -6741,7 +6538,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6760,7 +6556,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6779,7 +6574,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6798,7 +6592,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6830,7 +6623,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6849,7 +6641,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6868,7 +6659,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6887,7 +6677,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6906,7 +6695,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6935,7 +6723,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6954,7 +6741,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6970,7 +6756,6 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -6983,7 +6768,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -7002,7 +6786,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -7021,7 +6804,6 @@
       "propertyNames": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -7157,7 +6939,6 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -7225,8 +7006,6 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -7322,8 +7101,6 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -7354,8 +7131,6 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 9223372036854775808,
-            "minimum": -9223372036854775808,
             "type": "integer"
           },
           {
@@ -7422,7 +7197,6 @@
       "items": {
         "anyOf": [
           {
-            "exclusiveMaximum": 18446744073709551616,
             "minimum": 0,
             "type": "integer"
           },
@@ -7507,7 +7281,6 @@
     "single_fixed64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 18446744073709551616,
           "minimum": 0,
           "type": "integer"
         },
@@ -7563,8 +7336,6 @@
     "single_int64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854775808,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -7615,8 +7386,6 @@
     "single_sfixed64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854775808,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -7643,8 +7412,6 @@
     "single_sint64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 9223372036854775808,
-          "minimum": -9223372036854775808,
           "type": "integer"
         },
         {
@@ -7687,7 +7454,6 @@
     "single_uint64": {
       "anyOf": [
         {
-          "exclusiveMaximum": 18446744073709551616,
           "minimum": 0,
           "type": "integer"
         },

--- a/internal/testdata/jsonschema/google.protobuf.Int64Value.jsonschema.json
+++ b/internal/testdata/jsonschema/google.protobuf.Int64Value.jsonschema.json
@@ -3,8 +3,6 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "anyOf": [
     {
-      "exclusiveMaximum": 9223372036854775808,
-      "minimum": -9223372036854775808,
       "type": "integer"
     },
     {

--- a/internal/testdata/jsonschema/google.protobuf.Int64Value.schema.json
+++ b/internal/testdata/jsonschema/google.protobuf.Int64Value.schema.json
@@ -3,8 +3,6 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "anyOf": [
     {
-      "exclusiveMaximum": 9223372036854775808,
-      "minimum": -9223372036854775808,
       "type": "integer"
     },
     {

--- a/internal/testdata/jsonschema/google.protobuf.UInt64Value.jsonschema.json
+++ b/internal/testdata/jsonschema/google.protobuf.UInt64Value.jsonschema.json
@@ -3,7 +3,6 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "anyOf": [
     {
-      "exclusiveMaximum": 18446744073709551616,
       "minimum": 0,
       "type": "integer"
     },

--- a/internal/testdata/jsonschema/google.protobuf.UInt64Value.schema.json
+++ b/internal/testdata/jsonschema/google.protobuf.UInt64Value.schema.json
@@ -3,7 +3,6 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "anyOf": [
     {
-      "exclusiveMaximum": 18446744073709551616,
       "minimum": 0,
       "type": "integer"
     },


### PR DESCRIPTION
Standard JSON schema tooling rejects integers that are not interoperable as defined by: https://datatracker.ietf.org/doc/html/rfc8259#section-6

For example:
```
 protoschema-plugins % jsonschema bundle ./internal/gen/jsonschema/buf.protoschema.test.v1.ConstraintTest.schema.json --r ./internal/gen/jsonschema                   
error: The JSON value is not representable by the IETF RFC 8259 interoperable signed integer range at line 5 and column 23
  internal/gen/jsonschema/google.protobuf.Int64Value.jsonschema.json
```
This updates the generator to only output integers within the interoperable range.