### PR TITLE
Update to build with Go 1.24

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.x'
+          go-version: '1.24.x'
       - name: Test
         run: make test
       - name: Lint

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.x'
+          go-version: '1.24.x'
       - id: go-cache-paths
         shell: bash
         run: |

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ export PATH := $(BIN):$(PATH)
 export GOBIN := $(abspath $(BIN))
 BUF_VERSION = $(shell go list -m -f '{{.Version}}' github.com/bufbuild/buf)
 COPYRIGHT_YEARS := 2024-2025
-GOLANGCI_LINT_VERSION := v2.0.2
+GOLANGCI_LINT_VERSION := v2.1.6
+GOLANGCI_LINT := $(BIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 LICENSE_IGNORE := --ignore testdata/
 
 UNAME_OS := $(shell uname -s)
@@ -58,17 +59,17 @@ build: generate ## Build all packages
 	go build ./...
 
 .PHONY: lint
-lint: $(BIN)/golangci-lint $(BIN)/buf ## Lint
+lint: $(GOLANGCI_LINT) $(BIN)/buf ## Lint
 	go vet ./...
-	$(BIN)/golangci-lint fmt --diff
-	$(BIN)/golangci-lint run
+	$(GOLANGCI_LINT) fmt --diff
+	$(GOLANGCI_LINT) run
 	buf lint
 	buf format -d --exit-code
 
 .PHONY: lintfix
-lintfix: $(BIN)/golangci-lint ## Automatically fix some lint errors
-	$(BIN)/golangci-lint fmt
-	$(BIN)/golangci-lint run --fix
+lintfix: $(GOLANGCI_LINT) ## Automatically fix some lint errors
+	$(GOLANGCI_LINT) fmt
+	$(GOLANGCI_LINT) run --fix
 	buf format -w
 
 .PHONY: install
@@ -112,8 +113,9 @@ $(BIN)/buf: $(BIN) Makefile
 $(BIN)/license-header: $(BIN) Makefile
 	go install github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@$(BUF_VERSION)
 
-$(BIN)/golangci-lint: $(BIN) Makefile
+$(GOLANGCI_LINT): $(BIN) Makefile
 	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+	mv $(BIN)/golangci-lint $@
 
 $(BIN)/jv: $(BIN) Makefile
 	go install github.com/santhosh-tekuri/jsonschema/cmd/jv@latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bufbuild/protoschema-plugins
 
-go 1.23.0
+go 1.24
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-20250613105001-9f2d3c737feb.1

--- a/internal/protoschema/plugin/pluginjsonschema/pluginjsonschema_test.go
+++ b/internal/protoschema/plugin/pluginjsonschema/pluginjsonschema_test.go
@@ -16,7 +16,6 @@ package pluginjsonschema
 
 import (
 	"bytes"
-	"context"
 	"os"
 	"path"
 	"path/filepath"
@@ -55,7 +54,7 @@ func TestJSONSchemaHandler(t *testing.T) {
 	stdout := bytes.NewBuffer(nil)
 	stderr := bytes.NewBuffer(nil)
 	err = protoplugin.Run(
-		context.Background(),
+		t.Context(),
 		protoplugin.Env{
 			Stdin:  stdin,
 			Stdout: stdout,

--- a/internal/protoschema/plugin/pluginpubsub/pluginpubsub_test.go
+++ b/internal/protoschema/plugin/pluginpubsub/pluginpubsub_test.go
@@ -16,7 +16,6 @@ package pluginpubsub
 
 import (
 	"bytes"
-	"context"
 	"os"
 	"path"
 	"path/filepath"
@@ -57,7 +56,7 @@ func TestPubsubHandler(t *testing.T) {
 	stdout := bytes.NewBuffer(nil)
 	stderr := bytes.NewBuffer(nil)
 	err = protoplugin.Run(
-		context.Background(),
+		t.Context(),
 		protoplugin.Env{
 			Stdin:  stdin,
 			Stdout: stdout,


### PR DESCRIPTION
The latest version of Buf requires Go 1.24. Upgrade the CI build to use 1.24 instead of 1.23.