### PR TITLE
support UseProtoNames option

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ The JSON Schema plugin supports the following options:
   `true`, causing unknown fields to be ignored instead of erroring. Defaults to `false`. Useful when a
   client/sender may have a different version the schema than the server/receiver. Similar to the
   "ignore unknown fields" option in [Protobuf JSON](https://protobuf.dev/programming-guides/json/#json-options).
-- `use_proto_names` - if `true`, the generated schema will use proto field name instead of defaulting to a lowerCamelCase JSON field name. Defaults to `false`. Matches the behavior of [`protojson.MarshalOptions.UseProtoNames`](https://pkg.go.dev/google.golang.org/protobuf/encoding/protojson#MarshalOptions).
+- `use_proto_names` - if `true`, the generated schema will always use proto field name instead of defaulting to a lowerCamelCase JSON field name. Defaults to `false`. Matches the behavior of [`protojson.MarshalOptions.UseProtoNames`](https://pkg.go.dev/google.golang.org/protobuf/encoding/protojson#MarshalOptions).
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ The JSON Schema plugin supports the following options:
   `true`, causing unknown fields to be ignored instead of erroring. Defaults to `false`. Useful when a
   client/sender may have a different version the schema than the server/receiver. Similar to the
   "ignore unknown fields" option in [Protobuf JSON](https://protobuf.dev/programming-guides/json/#json-options).
+- `use_proto_names` - if `true`, the generated schema will use proto field name instead of defaulting to a lowerCamelCase JSON field name. Defaults to `false`. Matches the behavior of [`protojson.MarshalOptions.UseProtoNames`](https://pkg.go.dev/google.golang.org/protobuf/encoding/protojson#MarshalOptions).
 
 ## Community
 

--- a/internal/protoschema/jsonschema/jsonschema.go
+++ b/internal/protoschema/jsonschema/jsonschema.go
@@ -63,6 +63,14 @@ func WithJSONNames() GeneratorOption {
 	}
 }
 
+// WithProtoNames sets the generator to use proto field names as the primary name 
+// unless the json_name option is explicitly set.
+func WithUseProtoNames() GeneratorOption {
+	return func(p *Generator) {
+		p.useProtoNames = true
+	}
+}
+
 // WithAdditionalProperties sets the generator to allow additional properties on messages.
 func WithAdditionalProperties() GeneratorOption {
 	return func(p *Generator) {
@@ -107,6 +115,7 @@ type Generator struct {
 	schema               map[protoreflect.FullName]*msgSchema
 	custom               map[protoreflect.FullName]func(protoreflect.MessageDescriptor, *validate.FieldRules, map[string]any) error
 	useJSONNames         bool
+	useProtoNames        bool
 	additionalProperties bool
 	strict               bool
 	bundle               bool
@@ -277,11 +286,7 @@ func (p *Generator) generateMessage(entry *msgSchema) error {
 		}
 		if (rules.GetRequired() && rules.GetIgnore() != validate.Ignore_IGNORE_IF_ZERO_VALUE) || // Required by validate rules.
 			(p.strict && p.hasImplicitDefault(field, field.IsList() || field.IsMap(), rules)) { // Required by strict mode.
-			if p.useJSONNames {
-				required = append(required, field.JSONName())
-			} else {
-				required = append(required, string(field.Name()))
-			}
+			required = append(required, p.getPrimaryFieldName(field))
 		}
 
 		// Generate the schema.
@@ -315,31 +320,43 @@ func (p *Generator) addFieldProperties(
 	properties map[string]any) []string {
 	// TODO: Add an option to include custom alias.
 	aliases := make([]string, 0, 1)
-	if p.useJSONNames {
-		// Add the JSON name as the primary name.
-		if hide {
-			aliases = append(aliases, field.JSONName())
-		} else {
-			properties[field.JSONName()] = fieldSchema
-		}
-		// Add the proto name as an alias.
-		if field.JSONName() != string(field.Name()) {
-			aliases = append(aliases, string(field.Name()))
-		}
-		return aliases
-	}
 
-	// Add the proto name as the primary name.
-	if hide {
-		aliases = append(aliases, string(field.Name()))
+	// Determine the primary name to use.
+	primaryName := p.getPrimaryFieldName(field)
+	altName := p.getAltFieldName(field)
+
+	if (hide {
+		aliases = append(aliases, primaryName)
 	} else {
-		properties[string(field.Name())] = fieldSchema
+		properties[primaryName] = fieldSchema
 	}
-	// Add the JSON name as an alias.
-	if field.JSONName() != string(field.Name()) {
-		aliases = append(aliases, field.JSONName())
+	// Add the alternate name as an alias if different.
+	if altName != primaryName {
+		aliases = append(aliases, altName)
 	}
 	return aliases
+}
+
+// getPrimaryFieldName returns the primary field name to use in the JSON schema.
+func (p *Generator) getPrimaryFieldName(field protoreflect.FieldDescriptor) string {
+	if p.useProtoNames {
+		return string(field.Name())
+	}
+	if p.useJSONNames {
+		return field.JSONName()
+	}
+	return string(field.Name())
+}
+
+// getAltFieldName returns the alternate field name (alias) to use in the JSON schema.
+func (p *Generator) getAltFieldName(field protoreflect.FieldDescriptor) string {
+	if p.useProtoNames {
+		return field.JSONName()
+	}
+	if p.useJSONNames {
+		return string(field.Name())
+	}
+	return field.JSONName()
 }
 
 func (p *Generator) setDescription(desc protoreflect.Descriptor, schema map[string]any) {

--- a/internal/protoschema/jsonschema/jsonschema_test.go
+++ b/internal/protoschema/jsonschema/jsonschema_test.go
@@ -67,6 +67,45 @@ func TestTitle(t *testing.T) {
 	require.Equal(t, "FOO", nameToTitle("FOO"))
 }
 
+func TestUseProtoNames(t *testing.T) {
+	t.Parallel()
+	testDescs, err := golden.GetTestDescriptors("../../testdata")
+	require.NoError(t, err)
+	require.NotEmpty(t, testDescs)
+
+	// Use the Product message which has snake_case field names like product_id
+	var productDesc = testDescs[len(testDescs)-1]
+	require.Equal(t, "buf.protoschema.test.v1.Product", string(productDesc.FullName()))
+
+	// Test with UseProtoNames - should use snake_case field names
+	protoNamesGen := NewGenerator(WithUseProtoNames())
+	err = protoNamesGen.Add(productDesc)
+	require.NoError(t, err)
+	protoNamesSchemas := protoNamesGen.Generate()
+	protoSchema := protoNamesSchemas[productDesc.FullName()]
+	protoProps := protoSchema["properties"].(map[string]any)
+
+	// Should have snake_case names as primary
+	require.Contains(t, protoProps, "product_id")
+	require.Contains(t, protoProps, "product_name")
+	require.NotContains(t, protoProps, "productId")
+	require.NotContains(t, protoProps, "productName")
+
+	// Test with JSONNames - should use camelCase field names
+	jsonNamesGen := NewGenerator(WithJSONNames)
+	err = jsonNamesGen.Add(productDesc)
+	require.NoError(t, err)
+	jsonNamesSchemas := jsonNamesGen.Generate()
+	jsonSchema := jsonNamesSchemas[productDesc.FullName()]
+	jsonProps := jsonSchema["properties"].(map[string]any)
+
+	// Should have camelCase names as primary
+	require.Contains(t, jsonProps, "productId")
+	require.Contains(t, jsonProps, "productName")
+	require.NotContains(t, jsonProps, "product_id")
+	require.NotContains(t, jsonProps, "product_name")
+}
+
 func TestConstraints(t *testing.T) {
 	t.Parallel()
 	schemaPath := filepath.FromSlash("../../testdata/jsonschema/buf.protoschema.test.v1.ConstraintTests.schema.json")

--- a/internal/protoschema/plugin/pluginjsonschema/pluginjsonschema.go
+++ b/internal/protoschema/plugin/pluginjsonschema/pluginjsonschema.go
@@ -120,6 +120,12 @@ func parseOptions(param string) ([][]jsonschema.GeneratorOption, error) {
 				} else if value {
 					baseOpts = append(baseOpts, jsonschema.WithAdditionalProperties())
 				}
+			case "use_proto_names":
+				if value, err := parseBoolean(value); err != nil {
+					return nil, err
+				} else if value {
+					baseOpts = append(baseOpts, jsonschema.WithUseProtoNames())
+				}
 			case "target":
 				// Targets are delimited by '+', e.g. "proto+json".
 				targetsList := strings.Split(value, "+")


### PR DESCRIPTION
Add support for the useProtoNames option for generated JSON schemas. This provides an option that will generate JSON schemas using the original proto field names without autoconverting to lowerCamelCase. It will still respect the json_name option if explicitly set.