### PR TITLE
Add .github/release.yaml

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,6 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - dependabot[bot]


### PR DESCRIPTION
Mainly to avoid removing Dependabot PRs from the auto-generated release notes.